### PR TITLE
Converting all binary serialization to ASN.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,16 @@ authors = ["Andrew Danger Lyon <andrew@killtheradio.net>"]
 edition = "2018"
 
 [dependencies]
+argon2 = "0.3"
 base64 = "0.13"
+blake2 = "0.10"
 chacha20poly1305 = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
+crypto_box = "0.7"
 ed25519-dalek = { version = "1.0", features = ["serde"] }
 getset = "0.1"
 hmac = "0.12"
-rand = { version = "0.7", features = ["getrandom"] }
+rand = { version = "0.8", features = ["getrandom"] }
 rand_chacha = "0.2"
 rmp-serde = "0.15"
 serde = "1.0"
@@ -19,10 +22,8 @@ serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_yaml = "0.8"
 sha2 = "0.10"
-sodiumoxide = "0.2.6"
 thiserror = "1.0"
 url = { version = "2.2", features = ["serde"] }
-xsalsa20poly1305 = "0.8"
 
 [dev-dependencies]
 rmpv = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ hmac = "0.12"
 rand = { version = "0.8", features = ["getrandom"] }
 rand_chacha = "0.2"
 rmp-serde = "0.15"
+secrecy = { version = "0.7", features = ["serde"] }
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stamp-core"
 version = "0.1.0"
 authors = ["Andrew Danger Lyon <andrew@killtheradio.net>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 argon2 = "0.3"
@@ -16,8 +16,7 @@ getset = "0.1"
 hmac = "0.12"
 rand = { version = "0.8", features = ["getrandom"] }
 rand_chacha = "0.2"
-rmp-serde = "0.15"
-secrecy = { version = "0.7", features = ["serde"] }
+rasn = { path = "../support/rasn" }
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"
@@ -25,7 +24,5 @@ serde_yaml = "0.8"
 sha2 = "0.10"
 thiserror = "1.0"
 url = { version = "2.2", features = ["serde"] }
-
-[dev-dependencies]
-rmpv = { version = "0.4", features = ["serde"] }
+zeroize = { version = "1.3", features = ["zeroize_derive" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2018"
 base64 = "0.13"
 chacha20poly1305 = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
+ed25519-dalek = { version = "1.0", features = ["serde"] }
 getset = "0.1"
 hmac = "0.12"
-getrandom = "0.2"
+rand = { version = "0.7", features = ["getrandom"] }
+rand_chacha = "0.2"
 rmp-serde = "0.15"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,23 @@ version = "0.1.0"
 authors = ["Andrew Danger Lyon <andrew@killtheradio.net>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 base64 = "0.13"
+chacha20poly1305 = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 getset = "0.1"
+hmac = "0.12"
+getrandom = "0.2"
 rmp-serde = "0.15"
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_yaml = "0.8"
+sha2 = "0.10"
 sodiumoxide = "0.2.6"
 thiserror = "1.0"
 url = { version = "2.2", features = ["serde"] }
+xsalsa20poly1305 = "0.8"
 
 [dev-dependencies]
 rmpv = { version = "0.4", features = ["serde"] }

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -575,6 +575,11 @@ impl HmacKey {
         OsRng.fill_bytes(&mut randbuf);
         Ok(Self::HmacSha512(Vec::from(randbuf)))
     }
+
+    /// Create a new sha512 HMAC key from a byte array
+    pub fn new_sha512_from_bytes(keybytes: &[u8; 32]) -> Self {
+        Self::HmacSha512(Vec::from(&keybytes[..]))
+    }
 }
 
 /// An HMAC hash
@@ -838,6 +843,19 @@ pub(crate) mod tests {
         let salt = util::hash(id.as_ref()).unwrap();
         let master_key = derive_master_key("ZONING IS COMMUNISM".as_bytes(), &salt.as_ref(), KDF_OPS_INTERACTIVE, KDF_MEM_INTERACTIVE).unwrap();
         assert_eq!(master_key.as_ref(), &[148, 34, 57, 50, 168, 111, 176, 114, 120, 168, 159, 158, 96, 119, 14, 194, 52, 224, 58, 194, 77, 44, 168, 25, 54, 138, 172, 91, 164, 86, 190, 89]);
+    }
+
+    #[test]
+    fn hmac_result() {
+        let data = String::from("PARDON ME GOOD SIR DO YOU HAVE ANY goats FOR SALE!!!!!!?");
+        let hmac_key = HmacKey::new_sha512_from_bytes(&[
+            0, 1, 2, 3, 4, 5, 6, 7,
+            1, 2, 3, 4, 5, 6, 7, 8,
+            2, 3, 4, 5, 6, 7, 8, 9,
+            3, 4, 5, 6, 7, 8, 9, 9,
+        ]);
+        let hmac = Hmac::new_sha512(&hmac_key, data.as_bytes()).unwrap();
+        assert_eq!(hmac, Hmac::HmacSha512(vec![156, 55, 129, 245, 223, 131, 164, 169, 16, 253, 155, 213, 86, 246, 186, 151, 64, 222, 116, 203, 60, 141, 238, 58, 243, 10, 108, 239, 195, 253, 44, 24, 162, 111, 160, 243, 22, 144, 143, 251, 26, 48, 68, 19, 157, 53, 120, 83, 58, 193, 183, 100, 30, 220, 65, 80, 32, 47, 141, 1, 48, 195, 198, 0]));
     }
 
     #[test]

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -36,7 +36,6 @@ use sodiumoxide::{
     crypto::{
         box_::curve25519xsalsa20poly1305,
         pwhash::argon2id13,
-        //sign::ed25519,
     },
 };
 use std::convert::{TryInto, TryFrom};

--- a/src/crypto/message.rs
+++ b/src/crypto/message.rs
@@ -13,16 +13,20 @@ use crate::{
     },
     util::ser,
 };
+use rasn::{AsnType, Encode, Decode};
 use serde_derive::{Serialize, Deserialize};
 
 /// A wrapper around some encrypted message data, allowing us to provide easy
 /// serialization/deserialization methods.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, AsnType, Encode, Decode, Serialize, Deserialize)]
+#[rasn(choice)]
 pub enum Message {
     /// An anonymouse message without any signature information.
+    #[rasn(tag(explicit(0)))]
     Anonymous(Vec<u8>),
     /// A message signed by the sender that the recipient can use to verify the
     /// message came from where they think it came from.
+    #[rasn(tag(explicit(1)))]
     Signed(SignedObject<CryptoKeypairMessage>),
 }
 

--- a/src/crypto/message.rs
+++ b/src/crypto/message.rs
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn message_anonymous_signed_maybe() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let sender_key = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
         let recipient_key = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
 

--- a/src/crypto/message.rs
+++ b/src/crypto/message.rs
@@ -113,9 +113,9 @@ mod tests {
 
     #[test]
     fn message_anonymous_signed_maybe() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
-        let sender_key = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let recipient_key = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
+        let sender_key = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let recipient_key = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
 
         let sealed = recipient_key.seal(&master_key, &sender_key, b"'I KNOW!' SAID THE BOY, AS HE LEAPT TO HIS FEET").unwrap();
         let msg1 = Message::Signed(SignedObject::new(IdentityID::blank(), KeyID::random_crypto(), sealed));
@@ -168,7 +168,7 @@ mod tests {
 
         // now generate a NEW crypto key and try to open the message with it.
         let sender_identity2 = sender_identity
-            .add_subkey(Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&sender_master_key).unwrap()), "fake-ass-key", None).unwrap();
+            .add_subkey(Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&sender_master_key).unwrap()), "fake-ass-key", None).unwrap();
         let sender_fake_subkey = sender_identity2.keychain().subkey_by_name("fake-ass-key").unwrap();
         let res = open(&recipient_master_key, &recipient_subkey, &sender_fake_subkey, &sealed);
         assert_eq!(res, Err(Error::CryptoOpenFailed));

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -12,18 +12,22 @@ use crate::{
         IdentityID,
     },
 };
+use rasn::{AsnType, Encode, Decode};
 use serde_derive::{Serialize, Deserialize};
 
 /// A signature or object containing a signatur that lists the identity and key
 /// that created the signature.
-#[derive(Debug, Clone, Serialize, Deserialize, getset::Getters, getset::MutGetters, getset::Setters)]
+#[derive(Debug, Clone, AsnType, Encode, Decode, Serialize, Deserialize, getset::Getters, getset::MutGetters, getset::Setters)]
 #[getset(get = "pub", get_mut = "pub(crate)", set = "pub(crate)")]
 pub struct SignedObject<T> {
     /// The ID of the signing identity
+    #[rasn(tag(explicit(0)))]
     signed_by_identity: IdentityID,
     /// The ID of the key that signed the message
+    #[rasn(tag(explicit(1)))]
     signed_by_key: KeyID,
     /// The signature or message
+    #[rasn(tag(explicit(2)))]
     body: T,
 }
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -240,7 +240,7 @@ impl Eq for TransactionID {}
 #[cfg(test)]
 impl TransactionID {
     pub(crate) fn random_alpha() -> Self {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let sig = alpha_keypair.sign(&master_key, "hi im jerry".as_bytes()).unwrap();
         Self::Alpha(sig)
@@ -1122,7 +1122,7 @@ mod tests {
             stamp::Confidence,
         },
         private::{Private, MaybePrivate},
-        util::{self, Date},
+        util::{Date},
     };
     use std::str::FromStr;
     use url::Url;
@@ -1235,7 +1235,7 @@ mod tests {
                 TransactionBody::DeleteForwardV1(..) => {}
             }
         }
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1274,7 +1274,7 @@ mod tests {
 
     #[test]
     fn trans_entry_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let body = TransactionBody::MakeClaimV1(ClaimSpec::Name(MaybePrivate::new_private(&master_key, "Jackie Chrome".into()).unwrap()));
         let entry = TransactionEntry::new(Timestamp::now(), vec![TransactionID::random_alpha()], body);
         assert!(entry.has_private());
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[test]
     fn trans_new_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn trans_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1371,7 +1371,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_deref() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_graphinfo() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1433,7 +1433,7 @@ mod tests {
 
     fn genesis_time(now: Timestamp) -> (SecretKey, Transactions) {
         let transactions = Transactions::new();
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1853,7 +1853,7 @@ mod tests {
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -1873,7 +1873,7 @@ mod tests {
         let res = transactions2.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails"));
         assert_eq!(res.err(), Some(Error::DuplicateName));
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let res = transactions2.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_secret(secret_key), "default:secret", Some("Encrypt/decrypt things locally with this key"));
         assert_eq!(res.err(), Some(Error::DuplicateName));
@@ -1885,7 +1885,7 @@ mod tests {
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -1912,7 +1912,7 @@ mod tests {
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -2016,7 +2016,7 @@ mod tests {
         }
         let sig = identity.keychain().root().sign(&master_key, "KILL...ME....".as_bytes()).unwrap();
 
-        let master_key_new = SecretKey::new_xsalsa20poly1305();
+        let master_key_new = SecretKey::new_xsalsa20poly1305().unwrap();
         let transactions2 = transactions.reencrypt(&master_key, &master_key_new).unwrap();
         transactions2.test_master_key(&master_key_new).unwrap();
         let res = transactions2.test_master_key(&master_key);
@@ -2053,7 +2053,7 @@ mod tests {
         let root = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let transactions3 = transactions.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -2088,7 +2088,7 @@ mod tests {
     fn transactions_test_master_key() {
         let (master_key, transactions) = genesis();
         transactions.test_master_key(&master_key).unwrap();
-        let master_key_fake = SecretKey::new_xsalsa20poly1305();
+        let master_key_fake = SecretKey::new_xsalsa20poly1305().unwrap();
         assert!(master_key_fake != master_key);
         let res = transactions.test_master_key(&master_key_fake);
         assert_eq!(res.err(), Some(Error::CryptoOpenFailed));
@@ -2100,7 +2100,7 @@ mod tests {
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -240,7 +240,7 @@ impl Eq for TransactionID {}
 #[cfg(test)]
 impl TransactionID {
     pub(crate) fn random_alpha() -> Self {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let sig = alpha_keypair.sign(&master_key, "hi im jerry".as_bytes()).unwrap();
         Self::Alpha(sig)
@@ -1235,7 +1235,7 @@ mod tests {
                 TransactionBody::DeleteForwardV1(..) => {}
             }
         }
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1274,7 +1274,7 @@ mod tests {
 
     #[test]
     fn trans_entry_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let body = TransactionBody::MakeClaimV1(ClaimSpec::Name(MaybePrivate::new_private(&master_key, "Jackie Chrome".into()).unwrap()));
         let entry = TransactionEntry::new(Timestamp::now(), vec![TransactionID::random_alpha()], body);
         assert!(entry.has_private());
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[test]
     fn trans_new_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn trans_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1371,7 +1371,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_deref() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1391,7 +1391,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_graphinfo() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn trans_versioned_strip_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1433,7 +1433,7 @@ mod tests {
 
     fn genesis_time(now: Timestamp) -> (SecretKey, Transactions) {
         let transactions = Transactions::new();
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -1852,8 +1852,8 @@ mod tests {
         assert_eq!(identity.keychain().subkeys().len(), 0);
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -1869,11 +1869,11 @@ mod tests {
         let res = transactions2.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things"));
         assert_eq!(res.err(), Some(Error::DuplicateName));
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
         let res = transactions2.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails"));
         assert_eq!(res.err(), Some(Error::DuplicateName));
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let res = transactions2.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_secret(secret_key), "default:secret", Some("Encrypt/decrypt things locally with this key"));
         assert_eq!(res.err(), Some(Error::DuplicateName));
@@ -1884,8 +1884,8 @@ mod tests {
         let (master_key, transactions) = genesis();
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -1911,8 +1911,8 @@ mod tests {
         let (master_key, transactions) = genesis();
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -2016,7 +2016,7 @@ mod tests {
         }
         let sig = identity.keychain().root().sign(&master_key, "KILL...ME....".as_bytes()).unwrap();
 
-        let master_key_new = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key_new = SecretKey::new_xchacha20poly1305().unwrap();
         let transactions2 = transactions.reencrypt(&master_key, &master_key_new).unwrap();
         transactions2.test_master_key(&master_key_new).unwrap();
         let res = transactions2.test_master_key(&master_key);
@@ -2052,8 +2052,8 @@ mod tests {
         let publish = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let transactions3 = transactions.clone()
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()
@@ -2088,7 +2088,7 @@ mod tests {
     fn transactions_test_master_key() {
         let (master_key, transactions) = genesis();
         transactions.test_master_key(&master_key).unwrap();
-        let master_key_fake = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key_fake = SecretKey::new_xchacha20poly1305().unwrap();
         assert!(master_key_fake != master_key);
         let res = transactions.test_master_key(&master_key_fake);
         assert_eq!(res.err(), Some(Error::CryptoOpenFailed));
@@ -2099,8 +2099,8 @@ mod tests {
         let (master_key, transactions) = genesis();
 
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let transactions2 = transactions
             .add_subkey(&master_key, Timestamp::now(), Key::new_sign(sign_keypair), "default:sign", Some("The key I use to sign things")).unwrap()
             .add_subkey(&master_key, Timestamp::now(), Key::new_crypto(crypto_keypair), "default:crypto", Some("Use this to send me emails")).unwrap()

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,8 +126,8 @@ pub enum Error {
     DagOrderingError,
 
     /// An error while engaging in deserialization.
-    #[error("deserialization error")]
-    Deserialize(#[from] rmp_serde::decode::Error),
+    #[error("ASN.1 deserialization error")]
+    DeserializeASN,
 
     /// An error while engaging in deserialization.
     #[error("deserialization error")]
@@ -222,8 +222,8 @@ pub enum Error {
     RecoveryPolicyRequestPolicyMismatch,
 
     /// An error while engaging in msgpack serialization.
-    #[error("msgpack serialization error")]
-    SerializeMsgPack(#[from] rmp_serde::encode::Error),
+    #[error("ASN.1 serialization error")]
+    SerializeASN,
 
     /// An error while engaging in yaml serialization.
     #[error("yaml serialization error")]
@@ -232,6 +232,10 @@ pub enum Error {
     /// We're trying to verify a signature on a value, but it's missing.
     #[error("signature missing on a value")]
     SignatureMissing,
+
+    /// Error parsing a URL
+    #[error("URL parse error")]
+    Url(#[from] url::ParseError)
 }
 
 impl PartialEq for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
     #[error("could not update hash state")]
     CryptoHashStateUpdateError,
 
+    /// HMAC failed to build properly
+    #[error("HMAC failed to build properly")]
+    CryptoHmacBuildFailure,
+
     /// An HMAC failed to verify.
     #[error("the given HMAC combo does not verify")]
     CryptoHmacVerificationFailed,
@@ -59,6 +63,10 @@ pub enum Error {
     /// Failed to open a sealed message. This is a bummer, man.
     #[error("failed to open a sealed object")]
     CryptoOpenFailed,
+
+    /// Failed to seal a message.
+    #[error("failed to seal a message")]
+    CryptoSealFailed,
 
     /// Failed to produce a signature
     #[error("failed to create a signature")]
@@ -193,6 +201,10 @@ pub enum Error {
     /// Tried to open a private container that has no data
     #[error("attempt to open private object which has no data")]
     PrivateDataMissing,
+
+    /// Error generating random numbers
+    #[error("error generating random")]
+    Random,
 
     /// The recovery policy request's identity does not match the identity we're
     /// recovering.

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,11 @@ use thiserror::Error;
 /// which an expectation is not met or a problem occurs.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Trying to deserialize a value with the wrong length of data (ie, we
+    /// usually see this when trying to populate a [u8; 64]
+    #[error("incorrect data length")]
+    BadLength,
+
     /// Trying to use an xsalsa20poly1305 (or other) nonce with a
     /// NON-xsalsa20poly1305 algo, or vice versa, etc.
     #[error("cryptographic algorithm mismatch")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,8 @@ pub enum Error {
     #[error("incorrect data length")]
     BadLength,
 
-    /// Trying to use an xsalsa20poly1305 (or other) nonce with a
-    /// NON-xsalsa20poly1305 algo, or vice versa, etc.
+    /// Trying to use an xchacha20poly1305 (or other) nonce with a
+    /// NON-xchacha20poly1305 algo, or vice versa, etc.
     #[error("cryptographic algorithm mismatch")]
     CryptoAlgoMismatch,
 

--- a/src/identity/claim.rs
+++ b/src/identity/claim.rs
@@ -18,7 +18,9 @@ use crate::{
     util::{Timestamp, Date},
 };
 use getset;
+#[cfg(test)] use rand::RngCore;
 use serde_derive::{Serialize, Deserialize};
+use std::convert::TryInto;
 use std::ops::Deref;
 use url::Url;
 

--- a/src/identity/claim.rs
+++ b/src/identity/claim.rs
@@ -426,7 +426,7 @@ pub(crate) mod tests {
 
     macro_rules! make_specs {
         ($claimmaker:expr, $val:expr) => {{
-            let master_key = SecretKey::new_xsalsa20poly1305();
+            let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
             let val = $val;
             let maybe_private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
             let maybe_public = MaybePrivate::new_public(val.clone());
@@ -443,7 +443,7 @@ pub(crate) mod tests {
                 let val = $val;
                 let (master_key, spec_private, spec_public) = make_specs!($claimmaker, val.clone());
                 assert_eq!($get_maybe(spec_private.clone()).open(&master_key).unwrap(), val);
-                let master_key2 = SecretKey::new_xsalsa20poly1305();
+                let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
                 assert!(master_key != master_key2);
                 let spec_private2 = spec_private.reencrypt(&master_key, &master_key2).unwrap();
                 let maybe_private2 = $get_maybe(spec_private2);
@@ -470,7 +470,7 @@ pub(crate) mod tests {
         }
 
         let (master_key, _, spec) = make_specs!(|_, val| ClaimSpec::Identity(val), IdentityID::random());
-        let master_key2 = SecretKey::new_xsalsa20poly1305();
+        let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
         let spec2 = spec.clone().reencrypt(&master_key, &master_key2).unwrap();
         match (spec, spec2) {
             (ClaimSpec::Identity(id), ClaimSpec::Identity(id2)) => assert_eq!(id, id2),
@@ -554,7 +554,7 @@ pub(crate) mod tests {
         macro_rules! thtrip {
             (next, $val:expr, $createfn:expr) => {
                 let val = $val;
-                let master_key = SecretKey::new_xsalsa20poly1305();
+                let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
                 let private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
                 let claimspec = $createfn(private);
                 let claimspec2 = claimspec.clone().strip_private();
@@ -672,7 +672,7 @@ pub(crate) mod tests {
         macro_rules! as_pub {
             (raw, $claimmaker:expr, $val:expr, $getmaybe:expr) => {
                 let (master_key, spec_private, spec_public) = make_specs!($claimmaker, $val);
-                let fake_master_key = SecretKey::new_xsalsa20poly1305();
+                let fake_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
                 let container_private = ClaimContainer::new(ClaimID::random(), spec_private, Timestamp::now());
                 let container_public = ClaimContainer::new(ClaimID::random(), spec_public, Timestamp::now());
                 let opened_claim = container_private.claim().as_public(&master_key).unwrap();

--- a/src/identity/claim.rs
+++ b/src/identity/claim.rs
@@ -428,7 +428,7 @@ pub(crate) mod tests {
 
     macro_rules! make_specs {
         ($claimmaker:expr, $val:expr) => {{
-            let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+            let master_key = SecretKey::new_xchacha20poly1305().unwrap();
             let val = $val;
             let maybe_private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
             let maybe_public = MaybePrivate::new_public(val.clone());
@@ -445,7 +445,7 @@ pub(crate) mod tests {
                 let val = $val;
                 let (master_key, spec_private, spec_public) = make_specs!($claimmaker, val.clone());
                 assert_eq!($get_maybe(spec_private.clone()).open(&master_key).unwrap(), val);
-                let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+                let master_key2 = SecretKey::new_xchacha20poly1305().unwrap();
                 assert!(master_key != master_key2);
                 let spec_private2 = spec_private.reencrypt(&master_key, &master_key2).unwrap();
                 let maybe_private2 = $get_maybe(spec_private2);
@@ -472,7 +472,7 @@ pub(crate) mod tests {
         }
 
         let (master_key, _, spec) = make_specs!(|_, val| ClaimSpec::Identity(val), IdentityID::random());
-        let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key2 = SecretKey::new_xchacha20poly1305().unwrap();
         let spec2 = spec.clone().reencrypt(&master_key, &master_key2).unwrap();
         match (spec, spec2) {
             (ClaimSpec::Identity(id), ClaimSpec::Identity(id2)) => assert_eq!(id, id2),
@@ -556,7 +556,7 @@ pub(crate) mod tests {
         macro_rules! thtrip {
             (next, $val:expr, $createfn:expr) => {
                 let val = $val;
-                let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+                let master_key = SecretKey::new_xchacha20poly1305().unwrap();
                 let private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
                 let claimspec = $createfn(private);
                 let claimspec2 = claimspec.clone().strip_private();
@@ -674,7 +674,7 @@ pub(crate) mod tests {
         macro_rules! as_pub {
             (raw, $claimmaker:expr, $val:expr, $getmaybe:expr) => {
                 let (master_key, spec_private, spec_public) = make_specs!($claimmaker, $val);
-                let fake_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+                let fake_master_key = SecretKey::new_xchacha20poly1305().unwrap();
                 let container_private = ClaimContainer::new(ClaimID::random(), spec_private, Timestamp::now());
                 let container_public = ClaimContainer::new(ClaimID::random(), spec_public, Timestamp::now());
                 let opened_claim = container_private.claim().as_public(&master_key).unwrap();

--- a/src/identity/identity.rs
+++ b/src/identity/identity.rs
@@ -21,7 +21,9 @@ use crate::{
     },
 };
 use getset;
+#[cfg(test)] use rand::RngCore;
 use serde_derive::{Serialize, Deserialize};
+use std::convert::TryInto;
 use std::ops::Deref;
 
 object_id! {
@@ -862,25 +864,25 @@ mod tests {
         let ser = identity.serialize().unwrap();
         assert_eq!(ser, r#"---
 id:
-  Ed25519: ed2mesdW8i5YsIfoGjsJnP0sleJAi9zEkIsE6CnnvFlGSIHm9huG33MozicdqfKAzTI9rz8fpwu3MZbS4hCWCw
+  Ed25519: fCIX7Z3EiXIanC2819hWhF3oNW9gg6ujZKW8D_Y1lfZJJODmkkjVJlOZKCtM6YMa_fSS4i6Witse0k2UlZ-GAQ
 created: "1977-06-07T04:32:06Z"
 recovery_policy: ~
 keychain:
   alpha:
     Ed25519:
-      - rcxBT4vC93i4PZzwflbKUzTbvgf96wr4kArteWqwzxA
+      - dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
       - ~
   policy:
     Ed25519:
-      - _iO_wIyxzlWS0OvOKJYR67L80nQoNTCE_JYDcxs1lRk
+      - s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
       - ~
   publish:
     Ed25519:
-      - PRtrFNJJpYsNNYIZEgspwxVtgLqrMx1-3nXuLnTtWlc
+      - B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
       - ~
   root:
     Ed25519:
-      - Yl7xQtHuYPpQQwBfppPROI0jYqetVxvChC2EofFrNhU
+      - 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
       - ~
   subkeys: []
 claims: []

--- a/src/identity/identity.rs
+++ b/src/identity/identity.rs
@@ -494,7 +494,7 @@ mod tests {
     use std::str::FromStr;
 
     fn gen_master_key() -> SecretKey {
-        SecretKey::new_xsalsa20poly1305()
+        SecretKey::new_xsalsa20poly1305().unwrap()
     }
 
     fn create_identity() -> (SecretKey, Identity) {
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn identity_serialize() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let now = Timestamp::from_str("1977-06-07T04:32:06Z").unwrap();
         let seeds = [
             &[33, 90, 159, 88, 22, 24, 84, 4, 237, 121, 198, 195, 71, 238, 107, 91, 235, 93, 9, 129, 252, 221, 2, 149, 250, 142, 49, 36, 161, 184, 44, 156],

--- a/src/identity/keychain.rs
+++ b/src/identity/keychain.rs
@@ -651,13 +651,13 @@ mod tests {
 
     #[test]
     fn key_as_type() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = SecretKey::new_xchacha20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -680,13 +680,13 @@ mod tests {
 
     #[test]
     fn key_reencrypt() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = SecretKey::new_xchacha20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -703,7 +703,7 @@ mod tests {
         let val6_nonce = val6_key.gen_nonce().unwrap();
         let val6 = val6_key.seal(b"and your nose like a delicious slope of cream", &val6_nonce).unwrap();
 
-        let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key2 = SecretKey::new_xchacha20poly1305().unwrap();
         assert!(master_key != master_key2);
         let key1_2 = key1.reencrypt(&master_key, &master_key2).unwrap();
         let key2_2 = key2.reencrypt(&master_key, &master_key2).unwrap();
@@ -744,13 +744,13 @@ mod tests {
 
     #[test]
     fn key_strip_private_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = SecretKey::new_xchacha20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -789,7 +789,7 @@ mod tests {
     }
 
     fn keychain_new() -> (SecretKey, Keychain) {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -839,8 +839,8 @@ mod tests {
     fn keychain_subkeys_sign_verify_position() {
         let (master_key, keychain) = keychain_new();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
-        let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
+        let crypto_keypair = CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap();
         let sign = Key::new_sign(sign_keypair);
         let crypto = Key::new_crypto(crypto_keypair);
         let secret = Key::new_secret(secret_key);
@@ -899,7 +899,7 @@ mod tests {
     #[test]
     fn keychain_delete() {
         let (master_key, keychain) = keychain_new();
-        let crypto = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap());
+        let crypto = Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap());
         let keychain = keychain.add_subkey(crypto, "crypto", None).unwrap();
         // delete a key LOL
         let cryptokey = keychain.subkey_by_name("crypto").unwrap().clone();
@@ -913,8 +913,8 @@ mod tests {
     fn keychain_strip_private() {
         let (master_key, keychain) = keychain_new();
         let sign = Key::new_sign(SignKeypair::new_ed25519(&master_key).unwrap());
-        let crypto = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap());
-        let secret = Key::new_secret(Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap());
+        let crypto = Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap());
+        let secret = Key::new_secret(Private::seal(&master_key, &SecretKey::new_xchacha20poly1305().unwrap()).unwrap());
         let keychain = keychain
             .add_subkey(sign, "sign", None).unwrap()
             .add_subkey(crypto, "crypto", None).unwrap()

--- a/src/identity/keychain.rs
+++ b/src/identity/keychain.rs
@@ -651,13 +651,13 @@ mod tests {
 
     #[test]
     fn key_as_type() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305();
+        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -680,13 +680,13 @@ mod tests {
 
     #[test]
     fn key_reencrypt() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305();
+        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -700,10 +700,10 @@ mod tests {
         let val4 = key4.as_signkey().unwrap().sign(&master_key, b"hi i'm butch").unwrap();
         let val5 = key5.as_cryptokey().unwrap().seal_anonymous(b"sufferin succotash").unwrap();
         let val6_key = key6.as_secretkey().unwrap().open(&master_key).unwrap();
-        let val6_nonce = val6_key.gen_nonce();
+        let val6_nonce = val6_key.gen_nonce().unwrap();
         let val6 = val6_key.seal(b"and your nose like a delicious slope of cream", &val6_nonce).unwrap();
 
-        let master_key2 = SecretKey::new_xsalsa20poly1305();
+        let master_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
         assert!(master_key != master_key2);
         let key1_2 = key1.reencrypt(&master_key, &master_key2).unwrap();
         let key2_2 = key2.reencrypt(&master_key, &master_key2).unwrap();
@@ -744,13 +744,13 @@ mod tests {
 
     #[test]
     fn key_strip_private_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = SecretKey::new_xsalsa20poly1305();
+        let secret_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let key1 = Key::Policy(policy_keypair.clone());
         let key2 = Key::Publish(publish_keypair.clone());
         let key3 = Key::Root(root_keypair.clone());
@@ -789,7 +789,7 @@ mod tests {
     }
 
     fn keychain_new() -> (SecretKey, Keychain) {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -840,7 +840,7 @@ mod tests {
         let (master_key, keychain) = keychain_new();
         let sign_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
         let crypto_keypair = CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap();
-        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap();
+        let secret_key = Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap();
         let sign = Key::new_sign(sign_keypair);
         let crypto = Key::new_crypto(crypto_keypair);
         let secret = Key::new_secret(secret_key);
@@ -914,7 +914,7 @@ mod tests {
         let (master_key, keychain) = keychain_new();
         let sign = Key::new_sign(SignKeypair::new_ed25519(&master_key).unwrap());
         let crypto = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap());
-        let secret = Key::new_secret(Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305()).unwrap());
+        let secret = Key::new_secret(Private::seal(&master_key, &SecretKey::new_xsalsa20poly1305().unwrap()).unwrap());
         let keychain = keychain
             .add_subkey(sign, "sign", None).unwrap()
             .add_subkey(crypto, "crypto", None).unwrap()

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -187,14 +187,16 @@ mod tests {
 
             mod_trans!( published, trans, inner, {
                 let body = match inner.entry().body().clone() {
-                    TransactionBody::CreateIdentityV1(alpha, policy, publish, root) => {
+                    TransactionBody::CreateIdentityV1 { alpha, policy, publish, root } => {
                         let master_key = SecretKey::new_xchacha20poly1305().unwrap();
                         let new_alpha = AlphaKeypair::new_ed25519(&master_key).unwrap();
                         assert!(new_alpha != alpha);
-                        TransactionBody::CreateIdentityV1(new_alpha, policy, publish, root)
+                        TransactionBody::CreateIdentityV1 { alpha: new_alpha, policy, publish, root }
                     }
                     TransactionBody::Private => {
-                        TransactionBody::MakeClaimV1(ClaimSpec::Name(MaybePrivate::new_public(String::from("BAT MAN"))))
+                        TransactionBody::MakeClaimV1 {
+                            spec: ClaimSpec::Name(MaybePrivate::new_public(String::from("BAT MAN"))),
+                        }
                     }
                     _ => TransactionBody::Private,
                 };
@@ -230,57 +232,63 @@ mod tests {
         let ser = published.serialize().unwrap();
         assert_eq!(ser, r#"---
 publish_signature:
-  Ed25519: ouwBiHEHk6aludnxRhFJ5-eT2_hsnDNtV0DhWYn-BiS6M-L1fFlo3HlG4Q-D7B77GXLjN9c1D783KC2w5e99AA
+  Ed25519: aV6hwrK42EaRJe9uV705q0wk4H79Bsw9X0i4mGEgDEL1tCYsO5xCR56baanG4PS8-Im-g0_Wx8XSOTBmuGM8AQ
 publish_date: "1977-06-07T04:32:06Z"
 identity:
   transactions:
     - V1:
         id:
           Alpha:
-            Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
+            Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions: []
           body:
             CreateIdentityV1:
-              - Ed25519:
-                  - dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
-                  - ~
-              - Ed25519:
-                  - s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
-                  - ~
-              - Ed25519:
-                  - B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
-                  - ~
-              - Ed25519:
-                  - 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
-                  - ~
+              alpha:
+                Ed25519:
+                  public: dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
+                  secret: ~
+              policy:
+                Ed25519:
+                  public: s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
+                  secret: ~
+              publish:
+                Ed25519:
+                  public: B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
+                  secret: ~
+              root:
+                Ed25519:
+                  public: 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
+                  secret: ~
     - V1:
         id:
           Root:
-            Ed25519: 27C2RwGYtsZnFVrkv4QDIVWoJkb6g04BuBQY6mJo07IgCnxj7Q1Lta_ZMTtv3MOm1bRZnPvMLE1tvlj2AkqBAQ
+            Ed25519: OZ33QK8puJeHsMKP1Ag_4ai3s01_v6Z7FADVqCs5UnoeBAWWT4E9ZuuY7Oma2ZnKhw3QM2qLcr8PYXVTsOEPBA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Alpha:
-                Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
+                Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
           body:
             MakeClaimV1:
-              Identity:
-                Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
+              spec:
+                Identity:
+                  Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
     - V1:
         id:
           Root:
-            Ed25519: tu_FxF5tjcqxnSOE-au34-plcGcG9ljTLwJLgezoIVGrfZqPbomf21UY3TT3euYaRehXnIZFCGx_IOMLbI1yDw
+            Ed25519: sgBVjMhJK89W4e8ZxUvVU9XIy0O9dsPOv9TdHv2nuy0Mds0AoFnJMxB2ASZ0EY30wy3DOFHL55BdPaFhOrJPAA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Root:
-                Ed25519: 27C2RwGYtsZnFVrkv4QDIVWoJkb6g04BuBQY6mJo07IgCnxj7Q1Lta_ZMTtv3MOm1bRZnPvMLE1tvlj2AkqBAQ
+                Ed25519: OZ33QK8puJeHsMKP1Ag_4ai3s01_v6Z7FADVqCs5UnoeBAWWT4E9ZuuY7Oma2ZnKhw3QM2qLcr8PYXVTsOEPBA
           body:
             MakeClaimV1:
-              Name:
-                Public: Von Jonie Himself"#);
+              spec:
+                Name:
+                  Public: Von Jonie Himself"#);
         let published_des = PublishedIdentity::deserialize(ser.as_bytes()).unwrap();
         let identity_des = published_des.identity().build_identity().unwrap();
         assert_eq!(identity.claims().len(), 2);
@@ -296,57 +304,63 @@ identity:
         // we can even access the publish key to check the publish sig.
         let modified_claim = r#"---
 publish_signature:
-  Ed25519: sa63FcjCTJvb9m04xuUJrzo63Jn7oNAkfcw1V-SIpoiufFNQzBp65oI9QWDdq7aKym97JFw7cQ9-pyOY1wyUAw
+  Ed25519: aV6hwrK42EaRJe9uV705q0wk4H79Bsw9X0i4mGEgDEL1tCYsO5xCR56baanG4PS8-Im-g0_Wx8XSOTBmuGM8AQ
 publish_date: "1977-06-07T04:32:06Z"
 identity:
   transactions:
     - V1:
         id:
           Alpha:
-            Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+            Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions: []
           body:
             CreateIdentityV1:
-              - Ed25519:
-                  - rcxBT4vC93i4PZzwflbKUzTbvgf96wr4kArteWqwzxA
-                  - ~
-              - Ed25519:
-                  - _iO_wIyxzlWS0OvOKJYR67L80nQoNTCE_JYDcxs1lRk
-                  - ~
-              - Ed25519:
-                  - PRtrFNJJpYsNNYIZEgspwxVtgLqrMx1-3nXuLnTtWlc
-                  - ~
-              - Ed25519:
-                  - Yl7xQtHuYPpQQwBfppPROI0jYqetVxvChC2EofFrNhU
-                  - ~
+              alpha:
+                Ed25519:
+                  public: dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
+                  secret: ~
+              policy:
+                Ed25519:
+                  public: s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
+                  secret: ~
+              publish:
+                Ed25519:
+                  public: B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
+                  secret: ~
+              root:
+                Ed25519:
+                  public: 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
+                  secret: ~
     - V1:
         id:
           Root:
-            Ed25519: 6MrVBIEVXNRxnLAQZIuY41I9g5ximL0FkyNqh7AI5uRHgRtabThEyuQA9N5A4_6jKg9ClDr9Yb1YWbfzz_K1Dg
+            Ed25519: OZ33QK8puJeHsMKP1Ag_4ai3s01_v6Z7FADVqCs5UnoeBAWWT4E9ZuuY7Oma2ZnKhw3QM2qLcr8PYXVTsOEPBA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Alpha:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+                Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
           body:
             MakeClaimV1:
-              Identity:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+              spec:
+                Identity:
+                  Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
     - V1:
         id:
           Root:
-            Ed25519: k1pFH_SBskA4aj-AFgDB1oKZFsyHch2W3Lrqw5nO-A4gV7XOVp4_uyYztMpkF-P1NzuhJyNotAgCkfei8FflAA
+            Ed25519: sgBVjMhJK89W4e8ZxUvVU9XIy0O9dsPOv9TdHv2nuy0Mds0AoFnJMxB2ASZ0EY30wy3DOFHL55BdPaFhOrJPAA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Root:
-                Ed25519: 6MrVBIEVXNRxnLAQZIuY41I9g5ximL0FkyNqh7AI5uRHgRtabThEyuQA9N5A4_6jKg9ClDr9Yb1YWbfzz_K1Dg
+                Ed25519: OZ33QK8puJeHsMKP1Ag_4ai3s01_v6Z7FADVqCs5UnoeBAWWT4E9ZuuY7Oma2ZnKhw3QM2qLcr8PYXVTsOEPBA
           body:
             MakeClaimV1:
-              Name:
-                Public: Mr. Bovine Jonie"#;
+              spec:
+                Name:
+                  Public: Mr. Bovine Jonie"#;
 
         let res = PublishedIdentity::deserialize(modified_claim.as_bytes());
         assert_eq!(res.err(), Some(Error::CryptoSignatureVerificationFailed));
@@ -355,44 +369,49 @@ identity:
         // validation, but fail the publish signature check
         let modified_chain = r#"---
 publish_signature:
-  Ed25519: sa63FcjCTJvb9m04xuUJrzo63Jn7oNAkfcw1V-SIpoiufFNQzBp65oI9QWDdq7aKym97JFw7cQ9-pyOY1wyUAw
+  Ed25519: aV6hwrK42EaRJe9uV705q0wk4H79Bsw9X0i4mGEgDEL1tCYsO5xCR56baanG4PS8-Im-g0_Wx8XSOTBmuGM8AQ
 publish_date: "1977-06-07T04:32:06Z"
 identity:
   transactions:
     - V1:
         id:
           Alpha:
-            Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+            Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions: []
           body:
             CreateIdentityV1:
-              - Ed25519:
-                  - rcxBT4vC93i4PZzwflbKUzTbvgf96wr4kArteWqwzxA
-                  - ~
-              - Ed25519:
-                  - _iO_wIyxzlWS0OvOKJYR67L80nQoNTCE_JYDcxs1lRk
-                  - ~
-              - Ed25519:
-                  - PRtrFNJJpYsNNYIZEgspwxVtgLqrMx1-3nXuLnTtWlc
-                  - ~
-              - Ed25519:
-                  - Yl7xQtHuYPpQQwBfppPROI0jYqetVxvChC2EofFrNhU
-                  - ~
+              alpha:
+                Ed25519:
+                  public: dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
+                  secret: ~
+              policy:
+                Ed25519:
+                  public: s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
+                  secret: ~
+              publish:
+                Ed25519:
+                  public: B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
+                  secret: ~
+              root:
+                Ed25519:
+                  public: 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
+                  secret: ~
     - V1:
         id:
           Root:
-            Ed25519: 6MrVBIEVXNRxnLAQZIuY41I9g5ximL0FkyNqh7AI5uRHgRtabThEyuQA9N5A4_6jKg9ClDr9Yb1YWbfzz_K1Dg
+            Ed25519: OZ33QK8puJeHsMKP1Ag_4ai3s01_v6Z7FADVqCs5UnoeBAWWT4E9ZuuY7Oma2ZnKhw3QM2qLcr8PYXVTsOEPBA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Alpha:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+                Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg
           body:
             MakeClaimV1:
-              Identity:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw"#;
+              spec:
+                Identity:
+                  Ed25519: eQ5eek-FGJrTdUh_ceurqfGA9C6zth8hKOICmj1Jnsd5hrtKz8_NirwDMDh2bWkcxqaeT0e2CiAb8zqoEDkjBg"#;
         let res = PublishedIdentity::deserialize(modified_chain.as_bytes());
         assert_eq!(res.err(), Some(Error::CryptoSignatureVerificationFailed));
     }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -125,7 +125,7 @@ mod tests {
 
     fn get_transactions() -> (SecretKey, Transactions) {
         let now = Timestamp::now();
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -188,7 +188,7 @@ mod tests {
             mod_trans!( published, trans, inner, {
                 let body = match inner.entry().body().clone() {
                     TransactionBody::CreateIdentityV1(alpha, policy, publish, root) => {
-                        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+                        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
                         let new_alpha = AlphaKeypair::new_ed25519(&master_key).unwrap();
                         assert!(new_alpha != alpha);
                         TransactionBody::CreateIdentityV1(new_alpha, policy, publish, root)
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn published_serde() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let now = Timestamp::from_str("1977-06-07T04:32:06Z").unwrap();
         let seeds = [
             &[33, 90, 159, 88, 22, 24, 84, 4, 237, 121, 198, 195, 71, 238, 107, 91, 235, 93, 9, 129, 252, 221, 2, 149, 250, 142, 49, 36, 161, 184, 44, 156],

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -125,7 +125,7 @@ mod tests {
 
     fn get_transactions() -> (SecretKey, Transactions) {
         let now = Timestamp::now();
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
         let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
@@ -188,7 +188,7 @@ mod tests {
             mod_trans!( published, trans, inner, {
                 let body = match inner.entry().body().clone() {
                     TransactionBody::CreateIdentityV1(alpha, policy, publish, root) => {
-                        let master_key = SecretKey::new_xsalsa20poly1305();
+                        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
                         let new_alpha = AlphaKeypair::new_ed25519(&master_key).unwrap();
                         assert!(new_alpha != alpha);
                         TransactionBody::CreateIdentityV1(new_alpha, policy, publish, root)
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn published_serde() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let now = Timestamp::from_str("1977-06-07T04:32:06Z").unwrap();
         let seeds = [
             &[33, 90, 159, 88, 22, 24, 84, 4, 237, 121, 198, 195, 71, 238, 107, 91, 235, 93, 9, 129, 252, 221, 2, 149, 250, 142, 49, 36, 161, 184, 44, 156],

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -230,53 +230,53 @@ mod tests {
         let ser = published.serialize().unwrap();
         assert_eq!(ser, r#"---
 publish_signature:
-  Ed25519: sa63FcjCTJvb9m04xuUJrzo63Jn7oNAkfcw1V-SIpoiufFNQzBp65oI9QWDdq7aKym97JFw7cQ9-pyOY1wyUAw
+  Ed25519: ouwBiHEHk6aludnxRhFJ5-eT2_hsnDNtV0DhWYn-BiS6M-L1fFlo3HlG4Q-D7B77GXLjN9c1D783KC2w5e99AA
 publish_date: "1977-06-07T04:32:06Z"
 identity:
   transactions:
     - V1:
         id:
           Alpha:
-            Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+            Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions: []
           body:
             CreateIdentityV1:
               - Ed25519:
-                  - rcxBT4vC93i4PZzwflbKUzTbvgf96wr4kArteWqwzxA
+                  - dHNopBN3YZrNa52xiVxB1IoY9NsrCz1c9cL8lLTu69U
                   - ~
               - Ed25519:
-                  - _iO_wIyxzlWS0OvOKJYR67L80nQoNTCE_JYDcxs1lRk
+                  - s5YuvOaxr4y1qQBzZyJJ0SduYXf8toYfLa2izUgcT2I
                   - ~
               - Ed25519:
-                  - PRtrFNJJpYsNNYIZEgspwxVtgLqrMx1-3nXuLnTtWlc
+                  - B1NXKqP26jGll8tT12CCLbGxo09Do2M-A6VvRJoW87M
                   - ~
               - Ed25519:
-                  - Yl7xQtHuYPpQQwBfppPROI0jYqetVxvChC2EofFrNhU
+                  - 75w-F9acRAKDCDdeAiOYTAz9BUoky98lO5rHNSeodQg
                   - ~
     - V1:
         id:
           Root:
-            Ed25519: 6MrVBIEVXNRxnLAQZIuY41I9g5ximL0FkyNqh7AI5uRHgRtabThEyuQA9N5A4_6jKg9ClDr9Yb1YWbfzz_K1Dg
+            Ed25519: 27C2RwGYtsZnFVrkv4QDIVWoJkb6g04BuBQY6mJo07IgCnxj7Q1Lta_ZMTtv3MOm1bRZnPvMLE1tvlj2AkqBAQ
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Alpha:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+                Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
           body:
             MakeClaimV1:
               Identity:
-                Ed25519: gtFQEM2do4bIW0gkre1qahPsQZgny9rM1j9nWHuSWc0Ay492K8ydRljKCrCB-_G7aCsxMAMiBhuz9lyWwok5Aw
+                Ed25519: rdjnll1H48XN4WSaqXrCn_kwxv_cWF2tPl8lCa_KKtTNhbb2Qg2GaNHXQ01ScHW8KZNnsQckeorMy-MZpemgAA
     - V1:
         id:
           Root:
-            Ed25519: k1pFH_SBskA4aj-AFgDB1oKZFsyHch2W3Lrqw5nO-A4gV7XOVp4_uyYztMpkF-P1NzuhJyNotAgCkfei8FflAA
+            Ed25519: tu_FxF5tjcqxnSOE-au34-plcGcG9ljTLwJLgezoIVGrfZqPbomf21UY3TT3euYaRehXnIZFCGx_IOMLbI1yDw
         entry:
           created: "1977-06-07T04:32:06Z"
           previous_transactions:
             - Root:
-                Ed25519: 6MrVBIEVXNRxnLAQZIuY41I9g5ximL0FkyNqh7AI5uRHgRtabThEyuQA9N5A4_6jKg9ClDr9Yb1YWbfzz_K1Dg
+                Ed25519: 27C2RwGYtsZnFVrkv4QDIVWoJkb6g04BuBQY6mJo07IgCnxj7Q1Lta_ZMTtv3MOm1bRZnPvMLE1tvlj2AkqBAQ
           body:
             MakeClaimV1:
               Name:

--- a/src/identity/recovery.rs
+++ b/src/identity/recovery.rs
@@ -312,7 +312,7 @@ mod tests {
         let res = conditions.test(&vec![], &|_, _| Ok(()));
         assert_eq!(res.err(), Some(Error::PolicyConditionMismatch));
 
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
 
         let gus = SignKeypair::new_ed25519(&master_key).unwrap();
         let marty = SignKeypair::new_ed25519(&master_key).unwrap();
@@ -438,7 +438,7 @@ mod tests {
 
     #[test]
     fn policy_sign_request_validate_request() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let gus = SignKeypair::new_ed25519(&master_key).unwrap();
         let marty = SignKeypair::new_ed25519(&master_key).unwrap();
         let jackie = SignKeypair::new_ed25519(&master_key).unwrap();
@@ -524,7 +524,7 @@ mod tests {
 
     #[test]
     fn policy_request_new_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
@@ -561,7 +561,7 @@ mod tests {
 
     #[test]
     fn policy_request_reencrypt() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
@@ -580,7 +580,7 @@ mod tests {
             }
         };
 
-        let new_master_key = SecretKey::new_xsalsa20poly1305();
+        let new_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let req2 = req.reencrypt(&master_key, &new_master_key).unwrap();
 
         match req2.entry().action() {
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn policy_request_strip_private_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();

--- a/src/identity/recovery.rs
+++ b/src/identity/recovery.rs
@@ -47,7 +47,9 @@ use crate::{
     util::ser,
 };
 use getset;
+#[cfg(test)] use rand::RngCore;
 use serde_derive::{Serialize, Deserialize};
+use std::convert::TryInto;
 use std::ops::Deref;
 
 object_id! {

--- a/src/identity/recovery.rs
+++ b/src/identity/recovery.rs
@@ -314,7 +314,7 @@ mod tests {
         let res = conditions.test(&vec![], &|_, _| Ok(()));
         assert_eq!(res.err(), Some(Error::PolicyConditionMismatch));
 
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
 
         let gus = SignKeypair::new_ed25519(&master_key).unwrap();
         let marty = SignKeypair::new_ed25519(&master_key).unwrap();
@@ -440,7 +440,7 @@ mod tests {
 
     #[test]
     fn policy_sign_request_validate_request() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let gus = SignKeypair::new_ed25519(&master_key).unwrap();
         let marty = SignKeypair::new_ed25519(&master_key).unwrap();
         let jackie = SignKeypair::new_ed25519(&master_key).unwrap();
@@ -526,7 +526,7 @@ mod tests {
 
     #[test]
     fn policy_request_new_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn policy_request_reencrypt() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
@@ -582,7 +582,7 @@ mod tests {
             }
         };
 
-        let new_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let new_master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let req2 = req.reencrypt(&master_key, &new_master_key).unwrap();
 
         match req2.entry().action() {
@@ -597,7 +597,7 @@ mod tests {
 
     #[test]
     fn policy_request_strip_private_has_private() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let new_policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
         let new_publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
         let new_root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();

--- a/src/identity/stamp.rs
+++ b/src/identity/stamp.rs
@@ -328,8 +328,6 @@ mod tests {
 
     #[test]
     fn stamp_serde() {
-        let rand_id: String = String::from(&IdentityID::random());
-        println!("id1: {}", rand_id);
         let id1 = IdentityID::try_from("RUHyjlNbE7u7BCd9kp3_3jhKiC4w-8fpkox3HiTMD7gQDhGNS6dYCpJiU1C029gpqxjvLUmZmsokeQsjSC9gAAA").unwrap();
         let id2 = IdentityID::try_from("izTWRLHDYRY1qwkgxXgxe1D0Ft-TcJS95OpghVsplpu1S-5rpa7tGvCzmAVP9WhxKALZlOCiijAT1q6AMknuAAA").unwrap();
         let claim_id = ClaimID::try_from("K9fUQ28tp-azWhlysEyQisdt6qKh4-OEF1-ZYEetSVQuYQpa62DTREgAwtljpOYZZbrrxhBv7XnwBDDd9BFNAAA").unwrap();

--- a/src/identity/stamp.rs
+++ b/src/identity/stamp.rs
@@ -255,7 +255,7 @@ impl StampRequest {
     /// This re-encryptes the claim with a new key, then creates a signed
     /// message to the recipient (stamper) using one of their keys.
     pub fn new(sender_master_key: &SecretKey, sender_identity_id: &IdentityID, sender_key: &Subkey, recipient_key: &Subkey, claim: &Claim) -> Result<Message> {
-        let one_time_key = SecretKey::new_xsalsa20poly1305();
+        let one_time_key = SecretKey::new_xsalsa20poly1305()?;
         let claim_reencrypted_spec = claim.spec().clone().reencrypt(sender_master_key, &one_time_key)?;
         let mut claim_reencrypted = claim.clone();
         claim_reencrypted.set_spec(claim_reencrypted_spec);
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn stamp_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let sign_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let mut stamp = make_stamp(&master_key, &sign_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
         stamp.verify(&sign_keypair).unwrap();
@@ -353,7 +353,7 @@ entry:
 
     #[test]
     fn stamp_strip() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let stamp = make_stamp(&master_key, &root_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
         let stamp2 = stamp.strip_private();
@@ -370,7 +370,7 @@ entry:
         macro_rules! make_specs {
             ($claimmaker:expr, $val:expr) => {{
                 let val = $val;
-                let master_key = SecretKey::new_xsalsa20poly1305();
+                let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
                 let root_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
                 let maybe_private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
                 let maybe_public = MaybePrivate::new_public(val.clone());
@@ -396,7 +396,7 @@ entry:
                 let container_public = ClaimContainer::new(ClaimID::random(), spec_public, Timestamp::now());
                 let sender_subkey = sender_keychain.subkey_by_name("default:crypto").unwrap();
 
-                let recipient_master_key = SecretKey::new_xsalsa20poly1305();
+                let recipient_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
                 let subkey_key = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&recipient_master_key).unwrap());
                 let alpha = AlphaKeypair::new_ed25519(&sender_master_key).unwrap();
                 let policy = PolicyKeypair::new_ed25519(&sender_master_key).unwrap();
@@ -479,7 +479,7 @@ entry:
 
     #[test]
     fn stamp_revocation_create_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305();
+        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let stamp = make_stamp(&master_key, &root_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
 

--- a/src/identity/stamp.rs
+++ b/src/identity/stamp.rs
@@ -257,7 +257,7 @@ impl StampRequest {
     /// This re-encryptes the claim with a new key, then creates a signed
     /// message to the recipient (stamper) using one of their keys.
     pub fn new(sender_master_key: &SecretKey, sender_identity_id: &IdentityID, sender_key: &Subkey, recipient_key: &Subkey, claim: &Claim) -> Result<Message> {
-        let one_time_key = SecretKey::new_xsalsa20poly1305()?;
+        let one_time_key = SecretKey::new_xchacha20poly1305()?;
         let claim_reencrypted_spec = claim.spec().clone().reencrypt(sender_master_key, &one_time_key)?;
         let mut claim_reencrypted = claim.clone();
         claim_reencrypted.set_spec(claim_reencrypted_spec);
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn stamp_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let sign_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let mut stamp = make_stamp(&master_key, &sign_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
         stamp.verify(&sign_keypair).unwrap();
@@ -355,7 +355,7 @@ entry:
 
     #[test]
     fn stamp_strip() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let stamp = make_stamp(&master_key, &root_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
         let stamp2 = stamp.strip_private();
@@ -372,7 +372,7 @@ entry:
         macro_rules! make_specs {
             ($claimmaker:expr, $val:expr) => {{
                 let val = $val;
-                let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+                let master_key = SecretKey::new_xchacha20poly1305().unwrap();
                 let root_keypair = SignKeypair::new_ed25519(&master_key).unwrap();
                 let maybe_private = MaybePrivate::new_private(&master_key, val.clone()).unwrap();
                 let maybe_public = MaybePrivate::new_public(val.clone());
@@ -387,7 +387,7 @@ entry:
                 let val = $val;
                 let (sender_master_key, _root_keypair, spec_private, spec_public) = make_specs!($claimmaker, val.clone());
                 let sender_identity_id = IdentityID::random();
-                let subkey_key = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&sender_master_key).unwrap());
+                let subkey_key = Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&sender_master_key).unwrap());
                 let alpha = AlphaKeypair::new_ed25519(&sender_master_key).unwrap();
                 let policy = PolicyKeypair::new_ed25519(&sender_master_key).unwrap();
                 let publish = PublishKeypair::new_ed25519(&sender_master_key).unwrap();
@@ -398,8 +398,8 @@ entry:
                 let container_public = ClaimContainer::new(ClaimID::random(), spec_public, Timestamp::now());
                 let sender_subkey = sender_keychain.subkey_by_name("default:crypto").unwrap();
 
-                let recipient_master_key = SecretKey::new_xsalsa20poly1305().unwrap();
-                let subkey_key = Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&recipient_master_key).unwrap());
+                let recipient_master_key = SecretKey::new_xchacha20poly1305().unwrap();
+                let subkey_key = Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&recipient_master_key).unwrap());
                 let alpha = AlphaKeypair::new_ed25519(&sender_master_key).unwrap();
                 let policy = PolicyKeypair::new_ed25519(&sender_master_key).unwrap();
                 let publish = PublishKeypair::new_ed25519(&sender_master_key).unwrap();
@@ -481,7 +481,7 @@ entry:
 
     #[test]
     fn stamp_revocation_create_verify() {
-        let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let master_key = SecretKey::new_xchacha20poly1305().unwrap();
         let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
         let stamp = make_stamp(&master_key, &root_keypair, ClaimID::random(), &IdentityID::random(), &IdentityID::random(), None);
 

--- a/src/identity/stamp.rs
+++ b/src/identity/stamp.rs
@@ -22,7 +22,9 @@ use crate::{
     },
 };
 use getset;
+#[cfg(test)] use rand::RngCore;
 use serde_derive::{Serialize, Deserialize};
+use std::convert::TryInto;
 use std::ops::Deref;
 
 object_id! {
@@ -326,9 +328,11 @@ mod tests {
 
     #[test]
     fn stamp_serde() {
-        let id1 = IdentityID::try_from("Q8LwXx3nZvCn13Y49OydJ0OioG8_2idvEZGlmYeiBd2VHr5GOa5C3vxE_l-zWzhc5KcMiV_enu8LxpP4TIpUqwA").unwrap();
-        let id2 = IdentityID::try_from("c1lZ31CxrYGk4D3jXWrbhtetQ93kigNtJmOm09cptryHhOfeX3PMltqZet6Gql-7A0CkELbaqu_u1qXW95DkgAA").unwrap();
-        let claim_id = ClaimID::try_from("FG7ACMlbgAkT9mvJ6Qt8TACLQ-zQoE7o92VySsvHSUBnaSUlSbhRL8V6e0wnMu5aL6_Hy4HTXEllPF7rMTnQAQA").unwrap();
+        let rand_id: String = String::from(&IdentityID::random());
+        println!("id1: {}", rand_id);
+        let id1 = IdentityID::try_from("RUHyjlNbE7u7BCd9kp3_3jhKiC4w-8fpkox3HiTMD7gQDhGNS6dYCpJiU1C029gpqxjvLUmZmsokeQsjSC9gAAA").unwrap();
+        let id2 = IdentityID::try_from("izTWRLHDYRY1qwkgxXgxe1D0Ft-TcJS95OpghVsplpu1S-5rpa7tGvCzmAVP9WhxKALZlOCiijAT1q6AMknuAAA").unwrap();
+        let claim_id = ClaimID::try_from("K9fUQ28tp-azWhlysEyQisdt6qKh4-OEF1-ZYEetSVQuYQpa62DTREgAwtljpOYZZbrrxhBv7XnwBDDd9BFNAAA").unwrap();
         let master_key = key::tests::secret_from_vec(vec![58, 30, 74, 149, 49, 101, 115, 190, 250, 4, 99, 141, 245, 201, 209, 83, 46, 121, 28, 174, 1, 150, 149, 118, 181, 228, 215, 78, 226, 248, 53, 152]);
         let root_keypair = RootKeypair::new_ed25519_from_seed(&master_key, &[190, 106, 28, 143, 162, 234, 87, 8, 20, 209, 219, 44, 136, 152, 126, 189, 46, 129, 12, 125, 138, 173, 37, 220, 174, 42, 218, 199, 95, 127, 97, 92]).unwrap();
         let ts = Timestamp::from_str("2021-06-06T00:00:00-06:00").unwrap();
@@ -336,14 +340,14 @@ mod tests {
         let ser = stamp.serialize().unwrap();
         assert_eq!(ser, r#"---
 id:
-  Ed25519: zzCUbVE1VAhvEkQGARoK0Gfrlib232YzjUmFDwlEEdGF6xoNzgInhfKPCLFH5TQj3gZGdjJKsS6y5fFzuoixBw
+  Ed25519: 3cqOO1vDaIvAL8fx1EkfZb4b_9-3NvOsG1EieT4_aZfhHePrxEuaqXmuDkbOUwuzbYtomejye__677-0a8W0Bw
 entry:
   stamper:
-    Ed25519: Q8LwXx3nZvCn13Y49OydJ0OioG8_2idvEZGlmYeiBd2VHr5GOa5C3vxE_l-zWzhc5KcMiV_enu8LxpP4TIpUqw
+    Ed25519: RUHyjlNbE7u7BCd9kp3_3jhKiC4w-8fpkox3HiTMD7gQDhGNS6dYCpJiU1C029gpqxjvLUmZmsokeQsjSC9gAA
   stampee:
-    Ed25519: c1lZ31CxrYGk4D3jXWrbhtetQ93kigNtJmOm09cptryHhOfeX3PMltqZet6Gql-7A0CkELbaqu_u1qXW95DkgA
+    Ed25519: izTWRLHDYRY1qwkgxXgxe1D0Ft-TcJS95OpghVsplpu1S-5rpa7tGvCzmAVP9WhxKALZlOCiijAT1q6AMknuAA
   claim_id:
-    Ed25519: FG7ACMlbgAkT9mvJ6Qt8TACLQ-zQoE7o92VySsvHSUBnaSUlSbhRL8V6e0wnMu5aL6_Hy4HTXEllPF7rMTnQAQ
+    Ed25519: K9fUQ28tp-azWhlysEyQisdt6qKh4-OEF1-ZYEetSVQuYQpa62DTREgAwtljpOYZZbrrxhBv7XnwBDDd9BFNAA
   confidence: Medium
   date_signed: "2021-06-06T06:00:00Z"
   expires: ~"#);

--- a/src/identity/stamp.rs
+++ b/src/identity/stamp.rs
@@ -242,7 +242,7 @@ impl Public for Stamp {
 ///
 /// In the case of public claims, a simple "hey, can you stamp claim X" would
 /// suffice because the data is public.
-#[derive(Debug, Clone, Serialize, Deserialize, getset::Getters, getset::MutGetters, getset::Setters)]
+#[derive(Debug, Serialize, Deserialize, getset::Getters, getset::MutGetters, getset::Setters)]
 #[getset(get = "pub", get_mut = "pub(crate)", set = "pub(crate)")]
 pub struct StampRequest {
     /// The claim we wish to have stamped

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! The goals of this protocol are as follows:
 //!
 //! 1. To provide a semi-permanent container for a cryptographically-verified
-//! online identity.
+//! online/offline electronic identity.
 //! 1. To allow signing and verification of any number of custom pieces of
 //! information ("claims") that assert one's identity, including ones that are
 //! private and only accessible by the identity owner (and those who they choose

--- a/src/private.rs
+++ b/src/private.rs
@@ -83,7 +83,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Private<T> {
 ///
 /// This is a somewhat ephemeral container, mainly used for encryption and
 /// decryption and then thrown away.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct PrivateVerifiableInner<T> {
     /// The value we're storing.
     value: T,

--- a/src/private.rs
+++ b/src/private.rs
@@ -19,7 +19,7 @@ use serde_derive::{Serialize, Deserialize};
 use std::marker::PhantomData;
 
 /// Holds private data, which can only be opened if you have the special key.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Private<T> {
     /// Allows us to cast this container to T without this container ever
     /// actually storing any T value (because it's encrypted).
@@ -31,6 +31,16 @@ pub struct Private<T> {
     sealed: Vec<u8>,
     /// A nonce used to decrypt our heroic data (given the correct secret key).
     nonce: SecretKeyNonce,
+}
+
+impl<T> Clone for Private<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: PhantomData,
+            sealed: self.sealed.clone(),
+            nonce: self.nonce.clone(),
+        }
+    }
 }
 
 impl<T: serde::Serialize + serde::de::DeserializeOwned> Private<T> {

--- a/src/private.rs
+++ b/src/private.rs
@@ -299,11 +299,11 @@ mod tests {
 
     #[test]
     fn private_seal_open() {
-        let key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key = SecretKey::new_xchacha20poly1305().unwrap();
         let sealed: Private<String> = Private::seal(&key, &String::from("get a job")).unwrap();
         let opened: String = sealed.open(&key).unwrap();
         assert_eq!(&opened, "get a job");
-        let key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key2 = SecretKey::new_xchacha20poly1305().unwrap();
         assert!(key != key2);
         let res: Result<String> = sealed.open(&key2);
         assert_eq!(res, Err(Error::CryptoOpenFailed));
@@ -311,8 +311,8 @@ mod tests {
 
     #[test]
     fn private_reencrypt() {
-        let key1 = SecretKey::new_xsalsa20poly1305().unwrap();
-        let key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key1 = SecretKey::new_xchacha20poly1305().unwrap();
+        let key2 = SecretKey::new_xchacha20poly1305().unwrap();
         let sealed: Private<String> = Private::seal(&key1, &String::from("get a job")).unwrap();
         let sealed2 = sealed.reencrypt(&key1, &key2).unwrap();
         let opened: String = sealed2.open(&key2).unwrap();
@@ -323,11 +323,11 @@ mod tests {
 
     #[test]
     fn private_verifiable_seal_open() {
-        let key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key = SecretKey::new_xchacha20poly1305().unwrap();
         let (hmac, sealed) = PrivateVerifiable::<String>::seal(&key, &String::from("get a job")).unwrap();
         let opened: String = sealed.open_and_verify(&key, &hmac).unwrap();
         assert_eq!(&opened, "get a job");
-        let key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key2 = SecretKey::new_xchacha20poly1305().unwrap();
         assert!(key != key2);
         let res: Result<String> = sealed.open_and_verify(&key2, &hmac);
         assert_eq!(res, Err(Error::CryptoOpenFailed));
@@ -339,8 +339,8 @@ mod tests {
 
     #[test]
     fn private_verifiable_reencrypt() {
-        let key1 = SecretKey::new_xsalsa20poly1305().unwrap();
-        let key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let key1 = SecretKey::new_xchacha20poly1305().unwrap();
+        let key2 = SecretKey::new_xchacha20poly1305().unwrap();
         let (hmac, sealed) = PrivateVerifiable::<String>::seal(&key1, &String::from("get a job")).unwrap();
         let sealed2 = sealed.reencrypt(&key1, &key2).unwrap();
         let opened: String = sealed2.open_and_verify(&key2, &hmac).unwrap();
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn maybe_private_has_private() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
         let maybe1: MaybePrivate<String> = MaybePrivate::Public(String::from("hello"));
         let maybe2: MaybePrivate<String> = MaybePrivate::new_private(&seal_key, String::from("omg")).unwrap();
         let maybe3: MaybePrivate<String> = maybe2.strip_private();
@@ -363,10 +363,10 @@ mod tests {
 
     #[test]
     fn maybe_private_seal_open_verify_has_data() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
-        let mut fake_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
+        let mut fake_key = SecretKey::new_xchacha20poly1305().unwrap();
         // fake_key can never == seal_key. unfathomable, but possible.
-        while seal_key == fake_key { fake_key = SecretKey::new_xsalsa20poly1305().unwrap(); }
+        while seal_key == fake_key { fake_key = SecretKey::new_xchacha20poly1305().unwrap(); }
         let fake_hmac_key = HmacKey::new_sha512().unwrap();
 
         let maybe1: MaybePrivate<String> = MaybePrivate::Public(String::from("hello"));
@@ -395,10 +395,10 @@ mod tests {
 
     #[test]
     fn maybe_private_open_public() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
-        let mut fake_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
+        let mut fake_key = SecretKey::new_xchacha20poly1305().unwrap();
         // fake_key can never == seal_key. unfathomable, but possible.
-        while seal_key == fake_key { fake_key = SecretKey::new_xsalsa20poly1305().unwrap(); }
+        while seal_key == fake_key { fake_key = SecretKey::new_xchacha20poly1305().unwrap(); }
         let fake_hmac_key = HmacKey::new_sha512().unwrap();
 
         let maybe1: MaybePrivate<String> = MaybePrivate::Public(String::from("hello"));
@@ -412,8 +412,8 @@ mod tests {
 
     #[test]
     fn maybe_private_into_public() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
-        let fake_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
+        let fake_key = SecretKey::new_xchacha20poly1305().unwrap();
         assert!(seal_key != fake_key);
         let fake_hmac_key = HmacKey::new_sha512().unwrap();
 
@@ -433,8 +433,8 @@ mod tests {
 
     #[test]
     fn maybe_private_reencrypt_hmac() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
-        let seal_key2 = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
+        let seal_key2 = SecretKey::new_xchacha20poly1305().unwrap();
 
         let maybe1: MaybePrivate<String> = MaybePrivate::Public(String::from("hello"));
         let maybe2: MaybePrivate<String> = MaybePrivate::new_private(&seal_key, String::from("omg")).unwrap();
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn maybe_private_strip() {
-        let seal_key = SecretKey::new_xsalsa20poly1305().unwrap();
+        let seal_key = SecretKey::new_xchacha20poly1305().unwrap();
         let maybe: MaybePrivate<String> = MaybePrivate::new_private(&seal_key, String::from("omg")).unwrap();
         assert!(maybe.has_data());
         let maybe2 = maybe.strip_private();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,8 +1,11 @@
 //! Utilities. OBVIOUSLY.
 
 use blake2::Digest;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc, Local};
-use crate::error::Result;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc, Local, TimeZone};
+use crate::{
+    error::Result,
+};
+use rasn::{AsnType, Encode, Encoder, Decode, Decoder, Tag};
 use serde_derive::{Serialize, Deserialize};
 use std::ops::Deref;
 use std::str::FromStr;
@@ -13,7 +16,7 @@ pub(crate) mod sign;
 #[cfg(test)]
 pub(crate) mod test;
 
-pub use ser::{base64_encode, base64_decode, SerdeBinary};
+pub use ser::{base64_encode, base64_decode, SerdeBinary, Binary};
 
 macro_rules! object_id {
     (
@@ -23,6 +26,8 @@ macro_rules! object_id {
         #[derive(Debug, Clone, PartialEq, serde_derive::Serialize, serde_derive::Deserialize)]
         $(#[$meta])*
         pub struct $name(pub(crate) crate::crypto::key::SignKeypairSignature);
+
+        asn_encdec_newtype! { $name, crate::crypto::key::SignKeypairSignature }
 
         impl $name {
             /// Take a full string id and return the shortened ID
@@ -36,7 +41,7 @@ macro_rules! object_id {
         impl $name {
             pub(crate) fn blank() -> Self {
                 let sigbytes = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
-                let sig = crate::crypto::key::SignKeypairSignature::Ed25519(ed25519_dalek::Signature::from(sigbytes));
+                let sig = crate::crypto::key::SignKeypairSignature::Ed25519(crate::util::ser::Binary::new(sigbytes));
                 $name(sig)
             }
 
@@ -44,7 +49,7 @@ macro_rules! object_id {
                 let mut sigbytes = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
                 rand::rngs::OsRng.fill_bytes(&mut sigbytes);
                 sigbytes[ed25519_dalek::SIGNATURE_LENGTH - 1] = 0;
-                let sig = crate::crypto::key::SignKeypairSignature::Ed25519(ed25519_dalek::Signature::from(sigbytes));
+                let sig = crate::crypto::key::SignKeypairSignature::Ed25519(crate::util::ser::Binary::new(sigbytes));
                 $name(sig)
             }
         }
@@ -83,7 +88,7 @@ macro_rules! object_id {
                         let bytes_arr: [u8; ed25519_dalek::SIGNATURE_LENGTH] = bytes.try_into()
                             .map_err(|_| crate::error::Error::BadLength)?;
                         let sig = ed25519_dalek::Signature::from(bytes_arr);
-                        crate::crypto::key::SignKeypairSignature::Ed25519(sig)
+                        crate::crypto::key::SignKeypairSignature::Ed25519(crate::util::ser::Binary::new(sig.to_bytes()))
                     }
                 };
                 Ok(Self(id_sig))
@@ -130,11 +135,32 @@ impl Timestamp {
     }
 }
 
+impl AsnType for Timestamp {
+    const TAG: Tag = Tag::INTEGER;
+}
+
+impl Encode for Timestamp {
+    fn encode_with_tag<E: rasn::Encoder>(&self, encoder: &mut E, _tag: rasn::Tag) -> std::result::Result<(), E::Error> {
+        let ts = self.timestamp_millis();
+        ts.encode(encoder)?;
+        Ok(())
+    }
+}
+
+impl Decode for Timestamp {
+    fn decode_with_tag<D: rasn::Decoder>(decoder: &mut D, _tag: rasn::Tag) -> std::result::Result<Self, D::Error> {
+        let ts = <i64>::decode(decoder)?;
+        let dt = match chrono::Utc.timestamp_millis_opt(ts) {
+            chrono::offset::LocalResult::Single(dt) => dt,
+            _ => Err(rasn::de::Error::custom("could not deserialize Url"))?,
+        };
+        Ok(dt.into())
+    }
+}
+
 impl Deref for Timestamp {
     type Target = DateTime<Utc>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+    fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 impl From<NaiveDateTime> for Timestamp {
@@ -160,11 +186,40 @@ impl FromStr for Timestamp {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Date(NaiveDate);
 
+impl From<Timestamp> for Date {
+    fn from(ts: Timestamp) -> Self {
+        Self(ts.deref().date().naive_utc())
+    }
+}
+
+impl From<Date> for Timestamp {
+    fn from(date: Date) -> Self {
+        Self(DateTime::<Utc>::from_utc(date.and_hms(0, 0, 0), Utc))
+    }
+}
+
+impl AsnType for Date {
+    const TAG: Tag = Timestamp::TAG;
+}
+
+impl Encode for Date {
+    fn encode_with_tag<E: Encoder>(&self, encoder: &mut E, _tag: Tag) -> std::result::Result<(), E::Error> {
+        let ts: Timestamp = self.clone().into();
+        ts.encode(encoder)?;
+        Ok(())
+    }
+}
+
+impl Decode for Date {
+    fn decode_with_tag<D: Decoder>(decoder: &mut D, _tag: Tag) -> std::result::Result<Self, D::Error> {
+        let ts = Timestamp::decode(decoder)?;
+        Ok(ts.into())
+    }
+}
+
 impl Deref for Date {
     type Target = NaiveDate;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+    fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 impl From<NaiveDate> for Date {
@@ -195,10 +250,55 @@ pub trait PublicMaybe: Clone {
     fn strip_private_maybe(&self) -> Option<Self>;
 }
 
+
+/// A wrapper around URLs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Url(url::Url);
+
+impl Url {
+    pub fn parse(urlstr: &str) -> Result<Self> {
+        Ok(url::Url::parse(urlstr).map(|x| x.into())?)
+    }
+}
+
+impl Deref for Url {
+    type Target = url::Url;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl From<url::Url> for Url {
+    fn from(url: url::Url) -> Self {
+        Self(url)
+    }
+}
+
+impl AsnType for Url {
+    const TAG: Tag = Tag::UTF8_STRING;
+}
+
+impl Encode for Url {
+    fn encode_with_tag<E: Encoder>(&self, encoder: &mut E, _tag: Tag) -> std::result::Result<(), E::Error> {
+        let url_str: &str = self.deref().as_ref();
+        url_str.encode(encoder)?;
+        Ok(())
+    }
+}
+
+impl Decode for Url {
+    fn decode_with_tag<D: Decoder>(decoder: &mut D, tag: Tag) -> std::result::Result<Self, D::Error> {
+        let url_str: &str = &decoder.decode_utf8_string(tag)?;
+        let url = url::Url::parse(url_str)
+            .map_err(|_| rasn::de::Error::custom("could not deserialize Url"))?;
+        Ok(Self(url))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         crypto::key::{SignKeypairSignature},
+        util::ser::{self, Binary},
     };
     use rand::prelude::*;
     use std::convert::{TryFrom, TryInto};
@@ -212,7 +312,7 @@ mod tests {
 
         let sigbytes = vec![61, 47, 37, 255, 130, 49, 42, 60, 55, 247, 221, 146, 149, 13, 27, 227, 23, 228, 6, 170, 103, 177, 184, 3, 124, 102, 180, 148, 228, 67, 30, 140, 172, 59, 90, 94, 220, 123, 143, 239, 97, 164, 186, 213, 141, 217, 174, 43, 186, 16, 184, 236, 166, 130, 38, 5, 176, 33, 22, 5, 111, 171, 57, 2];
         let sigarr: [u8; 64] = sigbytes.try_into().unwrap();
-        let sig = SignKeypairSignature::Ed25519(ed25519_dalek::Signature::from(sigarr));
+        let sig = SignKeypairSignature::Ed25519(Binary::new(sigarr));
 
         let id = TestID(sig);
 
@@ -227,6 +327,42 @@ mod tests {
                 assert_eq!(sig, id.deref());
             }
         }
+    }
+
+    #[test]
+    fn timestamp_encdec() {
+        let date1 = Timestamp::from_str("1987-04-20T16:44:59.033Z").unwrap();
+        let ser1 = ser::serialize(&date1).unwrap();
+        let date1_2: Timestamp = ser::deserialize(ser1.as_slice()).unwrap();
+        assert_eq!(date1, date1_2);
+
+        let date2 = Timestamp::from_str("1957-12-03T00:10:19.998Z").unwrap();
+        let ser2 = ser::serialize(&date2).unwrap();
+        let date2_2: Timestamp = ser::deserialize(ser2.as_slice()).unwrap();
+        assert_eq!(date2, date2_2);
+
+        let date3 = Timestamp::from_str("890-08-14T14:56:01.003Z").unwrap();
+        let ser3 = ser::serialize(&date3).unwrap();
+        let date3_2: Timestamp = ser::deserialize(ser3.as_slice()).unwrap();
+        assert_eq!(date3, date3_2);
+    }
+
+    #[test]
+    fn date_encdec() {
+        let date1 = Date::from_str("1987-04-20").unwrap();
+        let ser1 = ser::serialize(&date1).unwrap();
+        let date1_2: Date = ser::deserialize(ser1.as_slice()).unwrap();
+        assert_eq!(date1, date1_2);
+
+        let date2 = Date::from_str("1957-12-03").unwrap();
+        let ser2 = ser::serialize(&date2).unwrap();
+        let date2_2: Date = ser::deserialize(ser2.as_slice()).unwrap();
+        assert_eq!(date2, date2_2);
+
+        let date3 = Date::from_str("890-08-14").unwrap();
+        let ser3 = ser::serialize(&date3).unwrap();
+        let date3_2: Date = ser::deserialize(ser3.as_slice()).unwrap();
+        assert_eq!(date3, date3_2);
     }
 }
 

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -8,18 +8,15 @@
 //! here and just make some serialization calls.
 
 use crate::{
-    error::Result,
+    error::{Error, Result},
     util::Public,
 };
-use serde::{Serialize, de::DeserializeOwned};
+use rasn::{AsnType, Encode, Encoder, Decode, Decoder, Tag};
+use serde::{Serialize, ser::Serializer, de::DeserializeOwned, de::Deserializer};
+use zeroize::Zeroize;
 
-pub(crate) fn serialize<T: Serialize>(obj: &T) -> Result<Vec<u8>> {
-    let mut buf = Vec::new();
-    let mut ser = rmp_serde::Serializer::new(&mut buf)
-        .with_binary()
-        .with_struct_tuple();
-    obj.serialize(&mut ser)?;
-    Ok(buf)
+pub(crate) fn serialize<T: Encode>(obj: &T) -> Result<Vec<u8>> {
+    Ok(rasn::der::encode(obj).map_err(|_| Error::SerializeASN)?)
 }
 
 pub(crate) fn serialize_human<T>(obj: &T) -> Result<String>
@@ -28,10 +25,8 @@ pub(crate) fn serialize_human<T>(obj: &T) -> Result<String>
     Ok(serde_yaml::to_string(&obj.strip_private())?)
 }
 
-pub(crate) fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
-    let obj = T::deserialize(&mut rmp_serde::Deserializer::new(bytes).with_binary())?;
-    //let obj = rmp_serde::from_read(bytes)?;
-    Ok(obj)
+pub(crate) fn deserialize<T: Decode>(bytes: &[u8]) -> Result<T> {
+    Ok(rasn::der::decode(bytes).map_err(|_| Error::DeserializeASN)?)
 }
 
 pub(crate) fn deserialize_human<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
@@ -49,7 +44,7 @@ pub fn base64_decode<T: AsRef<[u8]>>(bytes: T) -> Result<Vec<u8>> {
 
 /// A default implementation for (de)serializing an object to or from binary
 /// format.
-pub trait SerdeBinary: Serialize + DeserializeOwned {
+pub trait SerdeBinary: Encode + Decode {
     /// Serialize this message
     fn serialize_binary(&self) -> Result<Vec<u8>> {
         serialize(self)
@@ -61,78 +56,200 @@ pub trait SerdeBinary: Serialize + DeserializeOwned {
     }
 }
 
-pub trait TryFromSlice {
-    type Item;
-    fn try_from_slice(slice: &[u8]) -> std::result::Result<Self::Item, ()>;
-}
+/// Implements ASN.1 encoding/decoding for a newtype with a slicable member
+macro_rules! impl_asn1_binary {
+    ($name:ident) => {
+        impl<const N: usize> AsnType for $name<N> {
+            const TAG: Tag = Tag::OCTET_STRING;
+        }
 
-macro_rules! impl_try_from_slice {
-    ($class:ty, $slice:ident, $op:expr) => {
-        impl TryFromSlice for $class {
-            type Item = $class;
-            fn try_from_slice($slice: &[u8]) -> std::result::Result<Self::Item, ()> {
-                $op
+        impl<const N: usize> Encode for $name<N> {
+            fn encode_with_tag<E: Encoder>(&self, encoder: &mut E, tag: Tag) -> std::result::Result<(), E::Error> {
+                // Accepts a closure that encodes the contents of the sequence.
+                encoder.encode_octet_string(tag, &self.0[..])?;
+                Ok(())
             }
         }
-    };
 
-    ($class:ty) => {
-        impl_try_from_slice! { $class, slice, Self::from_slice(slice).ok_or(()) }
-    };
-}
-
-pub(crate) mod human_bytes {
-    use super::{base64_encode, base64_decode};
-    use serde::{Serializer, de, Deserialize, Deserializer};
-
-    pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&base64_encode(bytes.as_slice()))
-        } else {
-            serde_bytes::serialize(bytes, serializer)
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-        where D: Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = <String>::deserialize(deserializer)?;
-            base64_decode(s).map_err(de::Error::custom)
-        } else {
-            serde_bytes::deserialize(deserializer)
+        impl<const N: usize> Decode for $name<N> {
+            fn decode_with_tag<D: Decoder>(decoder: &mut D, tag: Tag) -> std::result::Result<Self, D::Error> {
+                let vec = decoder.decode_octet_string(tag)?;
+                let arr = vec.try_into()
+                    .map_err(|_| rasn::de::Error::no_valid_choice("octet string is incorrect length"))?;
+                Ok(Self(arr))
+            }
         }
     }
 }
 
-pub(crate) mod human_binary_from_slice {
-    use super::{TryFromSlice, base64_encode, base64_decode};
-    use serde::{Serializer, de, Deserialize, Deserializer};
+/// Defines a container for binary data in octet form. Effectively allows for
+/// strictly defining key/nonce/etc sizes and also allowing proper serialization
+/// and deserialization.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Binary<const N: usize>([u8; N]);
 
-    pub fn serialize<S, T>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer,
-              T: AsRef<[u8]> + serde::Serialize,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&base64_encode(bytes))
-        } else {
-            bytes.serialize(serializer)
-        }
+impl<const N: usize> Binary<N> {
+    pub fn new(bytes: [u8; N]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl_asn1_binary! { Binary }
+
+impl<const N: usize> std::ops::Deref for Binary<N> {
+    type Target = [u8; N];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> Serialize for Binary<N> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&base64_encode(&self.0[..]))
+    }
+}
+
+impl<'de, const N: usize> serde::Deserialize<'de> for Binary<N> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let s = <String>::deserialize(deserializer)?;
+        let tmp = base64_decode(s)
+            .map_err(serde::de::Error::custom)?
+            .try_into()
+            .map_err(|_| serde::de::Error::custom(String::from("bad slice length")))?;
+        Ok(Self(tmp))
+    }
+}
+
+/// Defines a container for SECRET binary data in octet form. This is just like
+/// [Binary] except that it implements Zeroize.
+#[derive(Zeroize)]
+#[zeroize(drop)]
+pub struct BinarySecret<const N: usize>([u8; N]);
+
+impl<const N: usize> BinarySecret<N> {
+    /// Create a new binary secret
+    pub fn new(bytes: [u8; N]) -> Self {
+        Self(bytes)
     }
 
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-        where D: Deserializer<'de>,
-              T: TryFromSlice + TryFromSlice<Item = T> + Deserialize<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = <String>::deserialize(deserializer)?;
-            let vec = base64_decode(s).map_err(de::Error::custom)?;
-            let val = T::try_from_slice(&vec[..]).map_err(|_| de::Error::custom(String::from("bad slice length")))?;
-            Ok(val)
-        } else {
-            T::deserialize(deserializer)
+    /// Grab the inner secret value.
+    pub fn expose_secret<'a>(&'a self) -> &'a [u8; N] {
+        &self.0
+    }
+}
+
+impl_asn1_binary! { BinarySecret }
+
+impl<const N: usize> std::fmt::Display for BinarySecret<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<secret>")
+    }
+}
+
+impl<const N: usize> std::fmt::Debug for BinarySecret<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<secret>")
+    }
+}
+
+impl<const N: usize> Serialize for BinarySecret<N> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&base64_encode(&self.0[..]))
+    }
+}
+
+impl<'de, const N: usize> serde::Deserialize<'de> for BinarySecret<N> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let s = <String>::deserialize(deserializer)?;
+        let tmp = base64_decode(s)
+            .map_err(serde::de::Error::custom)?
+            .try_into()
+            .map_err(|_| serde::de::Error::custom(String::from("bad slice length")))?;
+        Ok(Self(tmp))
+    }
+}
+
+/// Defines a container for binary data in octet form. Effectively allows for
+/// strictly defining key/nonce/etc sizes and also allowing proper serialization
+/// and deserialization.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinaryVec(Vec<u8>);
+
+impl std::convert::From<Vec<u8>> for BinaryVec {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(vec)
+    }
+}
+
+impl std::convert::From<BinaryVec> for Vec<u8> {
+    fn from(binary: BinaryVec) -> Self {
+        let BinaryVec(inner) = binary;
+        inner
+    }
+}
+
+impl std::ops::Deref for BinaryVec {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+#[cfg(test)]
+impl std::ops::DerefMut for BinaryVec {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}
+
+impl AsnType for BinaryVec {
+    const TAG: Tag = Tag::OCTET_STRING;
+}
+
+impl Encode for BinaryVec {
+    fn encode_with_tag<E: Encoder>(&self, encoder: &mut E, tag: Tag) -> std::result::Result<(), E::Error> {
+        // Accepts a closure that encodes the contents of the sequence.
+        encoder.encode_octet_string(tag, &self.0[..])?;
+        Ok(())
+    }
+}
+
+impl Decode for BinaryVec {
+    fn decode_with_tag<D: Decoder>(decoder: &mut D, tag: Tag) -> std::result::Result<Self, D::Error> {
+        let vec = decoder.decode_octet_string(tag)?;
+        Ok(Self(vec))
+    }
+}
+
+impl Serialize for BinaryVec {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&base64_encode(&self.0[..]))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for BinaryVec {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let s = <String>::deserialize(deserializer)?;
+        let tmp = base64_decode(s).map_err(serde::de::Error::custom)?;
+        Ok(Self(tmp))
+    }
+}
+
+macro_rules! asn_encdec_newtype {
+    ($name:ident, $inner:ty) => {
+        impl rasn::AsnType for $name {
+            const TAG: rasn::Tag = rasn::Tag::EOC;
+        }
+
+        impl rasn::Encode for $name {
+            fn encode_with_tag<E: rasn::Encoder>(&self, encoder: &mut E, _tag: rasn::Tag) -> std::result::Result<(), E::Error> {
+                // Accepts a closure that encodes the contents of the sequence.
+                self.0.encode(encoder)?;
+                Ok(())
+            }
+        }
+
+        impl rasn::Decode for $name {
+            fn decode_with_tag<D: rasn::Decoder>(decoder: &mut D, _tag: rasn::Tag) -> std::result::Result<Self, D::Error> {
+                let inner = <$inner>::decode(decoder)?;
+                Ok(Self(inner))
+            }
         }
     }
 }
@@ -161,168 +278,5 @@ pub(crate) mod timestamp {
             Ok(DateTime::<Utc>::from_utc(naive, Utc))
         }
     }
-}
-
-macro_rules! standard_impls {
-    ($struct:ident) => {
-        impl<T> std::ops::Deref for $struct<T> {
-            type Target = T;
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl<T> std::clone::Clone for $struct<T>
-            where T: std::clone::Clone,
-        {
-            fn clone(&self) -> Self {
-                Self(self.0.clone())
-            }
-        }
-
-        impl<T> std::cmp::PartialEq for $struct<T>
-            where T: std::cmp::PartialEq,
-        {
-            fn eq(&self, other: &Self) -> bool {
-                self.0 == other.0
-            }
-        }
-    }
-}
-
-macro_rules! base64_serde {
-    ($ty:ident, $ser_trait:ident, $de_trait: ident, $ser_fn:ident, $de_fn:ident, $tmp_ty:ty) => {
-        impl<T> serde::Serialize for $ty<T>
-            where T: $ser_trait,
-        {
-            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-                where S: serde::Serializer,
-            {
-                if serializer.is_human_readable() {
-                    serializer.serialize_str(&crate::util::ser::base64_encode(&self.0.$ser_fn()[..]))
-                } else {
-                    (*self.0.$ser_fn()).serialize(serializer)
-                }
-            }
-        }
-
-        impl<'de, T> serde::Deserialize<'de> for $ty<T>
-            where T: $de_trait
-        {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<$ty<T>, D::Error>
-                where D: serde::Deserializer<'de>,
-            {
-                if deserializer.is_human_readable() {
-                    let s = <String>::deserialize(deserializer)?;
-                    let tmp: $tmp_ty = crate::util::ser::base64_decode(s).map_err(serde::de::Error::custom)?
-                        .try_into()
-                        .map_err(|_| serde::de::Error::custom(String::from("bad slice length")))?;
-                    Ok($ty(T::$de_fn(tmp)))
-                } else {
-                    let tmp = <$tmp_ty>::deserialize(deserializer)?;
-                    Ok($ty(T::$de_fn(tmp)))
-                }
-            }
-        }
-    }
-}
-
-// TODO: remove this
-// this is dumb and i hate it
-macro_rules! define_byte_serializer {
-    ($as_trait:ident, $from_trait:ident, $wrapper:ident, $sermod:ident, $num_bytes:expr) => {
-        pub(crate) mod $sermod {
-            use super::{$as_trait, $from_trait, base64_encode, base64_decode};
-            use serde::{Serialize, Serializer, de, Deserialize, Deserializer};
-            use std::convert::TryInto;
-
-            pub fn serialize<S, T>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
-                where S: Serializer,
-                      T: $as_trait,
-            {
-                if serializer.is_human_readable() {
-                    serializer.serialize_str(&base64_encode(&val.to_ser()[..]))
-                } else {
-                    (*val.to_ser()).serialize(serializer)
-                }
-            }
-
-            pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-                where D: Deserializer<'de>,
-                      T: $from_trait,
-            {
-                if deserializer.is_human_readable() {
-                    let s = <String>::deserialize(deserializer)?;
-                    let vec = base64_decode(s).map_err(de::Error::custom)?;
-                    let arr: [u8; $num_bytes] = vec.try_into().map_err(|_| de::Error::custom(String::from("bad slice length")))?;
-                    Ok(T::from_des(arr))
-                } else {
-                    let bytes = <[u8; $num_bytes]>::deserialize(deserializer)?;
-                    Ok(T::from_des(bytes))
-                }
-            }
-        }
-    }
-}
-
-/// Assists in converting a type to a byte slice
-pub trait AsByteSlice {
-    /// Return the byte slice representaion of this object
-    fn to_ser(&self) -> &[u8];
-}
-
-/// Assists in building a type from a byte slice
-pub trait FromByteSlice {
-    /// Build this object from a byte slice
-    fn from_des(bytes: Vec<u8>) -> Self;
-}
-
-impl AsByteSlice for Vec<u8> {
-    fn to_ser(&self) -> &[u8] { self.as_slice() }
-}
-
-impl FromByteSlice for Vec<u8> {
-    fn from_des(bytes: Vec<u8>) -> Self {
-        bytes
-    }
-}
-
-macro_rules! define_base64_type {
-    ($name:ident, $ty:ty, $as_trait:ident, $from_trait:ident) => {
-        pub struct $name<T>(pub(crate) T);
-        standard_impls! { $name }
-        base64_serde! { $name, $as_trait, $from_trait, to_ser, from_des, $ty }
-    }
-}
-
-/// Assists in converting a type to a byte array
-pub trait AsByteArray32 {
-    /// Return the byte array representation of this object
-    fn to_ser(&self) -> &[u8; 32];
-}
-/// Assists in building a type from a byte array
-pub trait FromByteArray32 {
-    /// Build this object from a byte array
-    fn from_des(bytes: [u8; 32]) -> Self;
-}
-
-impl AsByteArray32 for [u8; 32] {
-    fn to_ser(&self) -> &[u8; 32] { &self }
-}
-
-impl FromByteArray32 for [u8; 32] {
-    fn from_des(bytes: [u8; 32]) -> Self {
-        bytes
-    }
-}
-
-define_byte_serializer! { AsByteArray32, FromByteArray32, Bytes32, human_bytes32, 32 }
-
-#[cfg(test)]
-#[allow(dead_code)]
-pub(crate) fn to_val<T: Serialize + DeserializeOwned>(obj: &T) -> std::result::Result<rmpv::Value, ()> {
-    let ser = serialize(obj).map_err(|_| ())?;
-    rmpv::decode::value::read_value(&mut &ser[..])
-        .map_err(|_| ())
 }
 

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -160,12 +160,43 @@ pub(crate) mod timestamp {
     }
 }
 
+macro_rules! standard_impls {
+    ($struct:ident) => {
+        impl<T> std::ops::Deref for $struct<T> {
+            type Target = T;
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<T> std::clone::Clone for $struct<T>
+            where T: std::clone::Clone,
+        {
+            fn clone(&self) -> Self {
+                Self(self.0.clone())
+            }
+        }
+
+        impl<T> std::cmp::PartialEq for $struct<T>
+            where T: std::cmp::PartialEq,
+        {
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+        }
+    }
+}
+
 macro_rules! define_byte_serializer {
     ($as_trait:ident, $from_trait:ident, $wrapper:ident, $sermod:ident, $num_bytes:expr) => {
+        /// Assists in converting a type to a byte array
         pub trait $as_trait {
+            /// Return the byte array representation of this object
             fn as_bytes(&self) -> &[u8; $num_bytes];
         }
+        /// Assists in building a type from a byte array
         pub trait $from_trait {
+            /// Build this object from a byte array
             fn from_bytes(bytes: [u8; $num_bytes]) -> Self;
         }
 
@@ -205,28 +236,7 @@ macro_rules! define_byte_serializer {
         #[allow(dead_code)]
         pub struct $wrapper<T>(pub(crate) T);
 
-        impl<T> std::ops::Deref for $wrapper<T> {
-            type Target = T;
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        impl<T> std::clone::Clone for $wrapper<T>
-            where T: std::clone::Clone,
-        {
-            fn clone(&self) -> Self {
-                Self(self.0.clone())
-            }
-        }
-
-        impl<T> std::cmp::PartialEq for $wrapper<T>
-            where T: std::cmp::PartialEq,
-        {
-            fn eq(&self, other: &Self) -> bool {
-                self.0 == other.0
-            }
-        }
+        standard_impls! { $wrapper }
 
         impl<T> serde::Serialize for $wrapper<T>
             where T: $as_trait,

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -187,19 +187,47 @@ macro_rules! standard_impls {
     }
 }
 
-macro_rules! define_byte_serializer {
-    ($as_trait:ident, $from_trait:ident, $wrapper:ident, $sermod:ident, $num_bytes:expr) => {
-        /// Assists in converting a type to a byte array
-        pub trait $as_trait {
-            /// Return the byte array representation of this object
-            fn as_bytes(&self) -> &[u8; $num_bytes];
-        }
-        /// Assists in building a type from a byte array
-        pub trait $from_trait {
-            /// Build this object from a byte array
-            fn from_bytes(bytes: [u8; $num_bytes]) -> Self;
+macro_rules! base64_serde {
+    ($ty:ident, $ser_trait:ident, $de_trait: ident, $ser_fn:ident, $de_fn:ident, $tmp_ty:ty) => {
+        impl<T> serde::Serialize for $ty<T>
+            where T: $ser_trait,
+        {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                where S: serde::Serializer,
+            {
+                if serializer.is_human_readable() {
+                    serializer.serialize_str(&crate::util::ser::base64_encode(&self.0.$ser_fn()[..]))
+                } else {
+                    (*self.0.$ser_fn()).serialize(serializer)
+                }
+            }
         }
 
+        impl<'de, T> serde::Deserialize<'de> for $ty<T>
+            where T: $de_trait
+        {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<$ty<T>, D::Error>
+                where D: serde::Deserializer<'de>,
+            {
+                if deserializer.is_human_readable() {
+                    let s = <String>::deserialize(deserializer)?;
+                    let tmp: $tmp_ty = crate::util::ser::base64_decode(s).map_err(serde::de::Error::custom)?
+                        .try_into()
+                        .map_err(|_| serde::de::Error::custom(String::from("bad slice length")))?;
+                    Ok($ty(T::$de_fn(tmp)))
+                } else {
+                    let tmp = <$tmp_ty>::deserialize(deserializer)?;
+                    Ok($ty(T::$de_fn(tmp)))
+                }
+            }
+        }
+    }
+}
+
+// TODO: remove this
+// this is dumb and i hate it
+macro_rules! define_byte_serializer {
+    ($as_trait:ident, $from_trait:ident, $wrapper:ident, $sermod:ident, $num_bytes:expr) => {
         pub(crate) mod $sermod {
             use super::{$as_trait, $from_trait, base64_encode, base64_decode};
             use serde::{Serialize, Serializer, de, Deserialize, Deserializer};
@@ -210,9 +238,9 @@ macro_rules! define_byte_serializer {
                       T: $as_trait,
             {
                 if serializer.is_human_readable() {
-                    serializer.serialize_str(&base64_encode(&val.as_bytes()[..]))
+                    serializer.serialize_str(&base64_encode(&val.to_ser()[..]))
                 } else {
-                    (*val.as_bytes()).serialize(serializer)
+                    (*val.to_ser()).serialize(serializer)
                 }
             }
 
@@ -224,44 +252,68 @@ macro_rules! define_byte_serializer {
                     let s = <String>::deserialize(deserializer)?;
                     let vec = base64_decode(s).map_err(de::Error::custom)?;
                     let arr: [u8; $num_bytes] = vec.try_into().map_err(|_| de::Error::custom(String::from("bad slice length")))?;
-                    Ok(T::from_bytes(arr))
+                    Ok(T::from_des(arr))
                 } else {
                     let bytes = <[u8; $num_bytes]>::deserialize(deserializer)?;
-                    Ok(T::from_bytes(bytes))
+                    Ok(T::from_des(bytes))
                 }
-            }
-        }
-
-        #[derive(Debug)]
-        #[allow(dead_code)]
-        pub struct $wrapper<T>(pub(crate) T);
-
-        standard_impls! { $wrapper }
-
-        impl<T> serde::Serialize for $wrapper<T>
-            where T: $as_trait,
-        {
-            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-                where S: serde::Serializer,
-            {
-                self.0.as_bytes().serialize(serializer)
-            }
-        }
-
-        impl<'de, T> serde::Deserialize<'de> for $wrapper<T>
-            where T: $from_trait
-        {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<$wrapper<T>, D::Error>
-                where D: serde::Deserializer<'de>,
-            {
-                let bytes = <[u8; $num_bytes]>::deserialize(deserializer)?;
-                Ok($wrapper(T::from_bytes(bytes)))
             }
         }
     }
 }
 
-define_byte_serializer! { AsBytes32, FromBytes32, Bytes32, human_bytes32, 32 }
+/// Assists in converting a type to a byte slice
+pub trait AsByteSlice {
+    /// Return the byte slice representaion of this object
+    fn to_ser(&self) -> &[u8];
+}
+
+/// Assists in building a type from a byte slice
+pub trait FromByteSlice {
+    /// Build this object from a byte slice
+    fn from_des(bytes: Vec<u8>) -> Self;
+}
+
+impl AsByteSlice for Vec<u8> {
+    fn to_ser(&self) -> &[u8] { self.as_slice() }
+}
+
+impl FromByteSlice for Vec<u8> {
+    fn from_des(bytes: Vec<u8>) -> Self {
+        bytes
+    }
+}
+
+macro_rules! define_base64_type {
+    ($name:ident, $ty:ty, $as_trait:ident, $from_trait:ident) => {
+        pub struct $name<T>(pub(crate) T);
+        standard_impls! { $name }
+        base64_serde! { $name, $as_trait, $from_trait, to_ser, from_des, $ty }
+    }
+}
+
+/// Assists in converting a type to a byte array
+pub trait AsByteArray32 {
+    /// Return the byte array representation of this object
+    fn to_ser(&self) -> &[u8; 32];
+}
+/// Assists in building a type from a byte array
+pub trait FromByteArray32 {
+    /// Build this object from a byte array
+    fn from_des(bytes: [u8; 32]) -> Self;
+}
+
+impl AsByteArray32 for [u8; 32] {
+    fn to_ser(&self) -> &[u8; 32] { &self }
+}
+
+impl FromByteArray32 for [u8; 32] {
+    fn from_des(bytes: [u8; 32]) -> Self {
+        bytes
+    }
+}
+
+define_byte_serializer! { AsByteArray32, FromByteArray32, Bytes32, human_bytes32, 32 }
 
 #[cfg(test)]
 #[allow(dead_code)]

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -15,7 +15,10 @@ use serde::{Serialize, de::DeserializeOwned};
 
 pub(crate) fn serialize<T: Serialize>(obj: &T) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
-    obj.serialize(&mut rmp_serde::Serializer::new(&mut buf).with_binary())?;
+    let mut ser = rmp_serde::Serializer::new(&mut buf)
+        .with_binary()
+        .with_struct_tuple();
+    obj.serialize(&mut ser)?;
     Ok(buf)
 }
 

--- a/src/util/sign.rs
+++ b/src/util/sign.rs
@@ -4,13 +4,13 @@ use crate::{
     util::Timestamp,
 };
 use getset;
-use serde_derive::Serialize;
+use rasn::{AsnType, Encode, Encoder, Tag, types::Class};
 
 /// Attaches a serializable object to a date for signing.
 ///
 /// This is a one-way object used for comparing signatures, so never needs to be
 /// deserialized.
-#[derive(Debug, Clone, Serialize, getset::Getters, getset::MutGetters, getset::Setters)]
+#[derive(Debug, Clone, AsnType, getset::Getters, getset::MutGetters, getset::Setters)]
 pub struct DateSigner<'a, 'b, T> {
     /// The date we signed this value.
     date: &'a Timestamp,
@@ -18,7 +18,7 @@ pub struct DateSigner<'a, 'b, T> {
     value: &'b T,
 }
 
-impl<'a, 'b, T: serde::Serialize> DateSigner<'a, 'b, T> {
+impl<'a, 'b, T: Encode> DateSigner<'a, 'b, T> {
     /// Construct a new DateSigner
     pub fn new(date: &'a Timestamp, value: &'b T) -> Self {
         Self {
@@ -28,9 +28,20 @@ impl<'a, 'b, T: serde::Serialize> DateSigner<'a, 'b, T> {
     }
 }
 
+impl<'a, 'b, T: Encode> Encode for DateSigner<'a, 'b, T> {
+    fn encode_with_tag<E: Encoder>(&self, encoder: &mut E, tag: Tag) -> Result<(), E::Error> {
+        encoder.encode_sequence(tag, |encoder| {
+            encoder.encode_explicit_prefix(Tag::new(Class::Context, 0), &self.date)?;
+            encoder.encode_explicit_prefix(Tag::new(Class::Context, 1), &self.value)?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
+
 /// A trait that allows an object to return a signable representation of itself.
 pub trait Signable {
-    type Item: serde::Serialize;
+    type Item: Encode;
 
     /// Return the unserialized data that will be signed for this item.
     fn signable(&self) -> Self::Item;

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -10,12 +10,13 @@ use std::thread;
 use std::time::Duration;
 
 /// Go to sleeeeep
+#[allow(dead_code)]
 pub(crate) fn sleep(millis: u64) {
     thread::sleep(Duration::from_millis(millis));
 }
 
 pub(crate) fn setup_identity_with_subkeys() -> (SecretKey, Identity) {
-    let master_key = SecretKey::new_xsalsa20poly1305();
+    let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
     let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
     let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
     let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -16,14 +16,14 @@ pub(crate) fn sleep(millis: u64) {
 }
 
 pub(crate) fn setup_identity_with_subkeys() -> (SecretKey, Identity) {
-    let master_key = SecretKey::new_xsalsa20poly1305().unwrap();
+    let master_key = SecretKey::new_xchacha20poly1305().unwrap();
     let alpha_keypair = AlphaKeypair::new_ed25519(&master_key).unwrap();
     let policy_keypair = PolicyKeypair::new_ed25519(&master_key).unwrap();
     let publish_keypair = PublishKeypair::new_ed25519(&master_key).unwrap();
     let root_keypair = RootKeypair::new_ed25519(&master_key).unwrap();
     let identity = Identity::create(IdentityID::random(), alpha_keypair, policy_keypair, publish_keypair, root_keypair, Timestamp::now())
         .add_subkey(Key::new_sign(SignKeypair::new_ed25519(&master_key).unwrap()), "sign", None).unwrap()
-        .add_subkey(Key::new_crypto(CryptoKeypair::new_curve25519xsalsa20poly1305(&master_key).unwrap()), "cryptololol", None).unwrap();
+        .add_subkey(Key::new_crypto(CryptoKeypair::new_curve25519xchacha20poly1305(&master_key).unwrap()), "cryptololol", None).unwrap();
     (master_key, identity)
 }
 


### PR DESCRIPTION
this one was a fucking doozy. ripped out all msgpack and replaced with
ASN.1 DER (via the wonderful and capable rasn crate).

this wasn't just adding a bunch of dumb #[derive(...)] macros, but
actually changing the fundamental structure of a lot of enums. this was
because multi-tuple enum variants (ie `MyEnum::Keypair(public, secret)`)
cannot be serialized via the current derive macros for rasn (or, for ANY
ASN.1 implementation to be fair). instead of adding it, instead i
decided to just refactor those variants into named struct enum variants.
this is much more clear, if not a bit more verbose.

this obviously changed how signatures are created because ANS.1 =/=
MsgPack so a lot of the tests had to change.

overall, this is for the better. i ignored ASN.1 for years because i
thought it was some antiquated format, but it's purpose-built for
EXACTLY our use-case and much more expressive than any of the other
binary serialization formats (protobufs, msgpack, etc). i can't believe
more people don't use it. WTF.

anyway, tests passing (including some new ones to head some issues that
came up during the conversion off at the pass).

what a wild ride.
